### PR TITLE
fix github build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
+ARG TARGET_PLATFORM=linux/amd64
+FROM --platform=$TARGET_PLATFORM public.ecr.aws/awsguru/rust-builder as build-stage
 ARG ARCH=x86_64
-RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
-RUN yum groupinstall -y "Development tools"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
-RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
-        && tar zxf /${ARCH}-linux-musl-cross.tgz \
-        && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
 WORKDIR /app
 ADD . /app
 RUN source $HOME/.cargo/env &&\

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
+ARG ARCH=x86_64
+RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
+RUN yum groupinstall -y "Development tools"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
+RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
+        && tar zxf /${ARCH}-linux-musl-cross.tgz \
+        && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,29 @@ CARGO_PKG_VERSION := $(shell cargo metadata --no-deps --format-version=1 | jq -r
 clean:
 	rm -rf target
 
+build-builder-x86:
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile.builder --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/rust-builder:latest-x86_64 .
+
+build-builder-arm64:
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile.builder --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/rust-builder:latest-aarch64 .
+
+build-builder: build-builder-x86 build-builder-arm64
+	docker push public.ecr.aws/awsguru/rust-builder:latest-x86_64
+	docker push public.ecr.aws/awsguru/rust-builder:latest-aarch64
+	docker manifest create public.ecr.aws/awsguru/rust-builder:latest \
+				public.ecr.aws/awsguru/rust-builder:latest-x86_64 \
+				public.ecr.aws/awsguru/rust-builder:latest-aarch64
+	docker manifest annotate --arch arm64 public.ecr.aws/awsguru/rust-builder:latest \
+				public.ecr.aws/awsguru/rust-builder:latest-aarch64
+
+publish-builder:
+	docker manifest push public.ecr.aws/awsguru/rust-builder:latest
+
 build-x86:
-	DOCKER_BUILDKIT=1 docker build --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-x86_64 .
+	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/amd64 --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-x86_64 .
 
 build-arm:
-	DOCKER_BUILDKIT=1 docker build --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-aarch64 .
+	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-aarch64 .
 
 build: build-x86 build-arm
 	docker push public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-x86_64


### PR DESCRIPTION
GitHub build is failing because of not being able to download musl cross compiler. This PR fix it by use a prebuild `rust-builder` image.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
