### PR TITLE
fix Adapter Layer Version Permission

### DIFF
--- a/template-arm64.yaml
+++ b/template-arm64.yaml
@@ -11,6 +11,7 @@ Resources:
       CompatibleArchitectures:
         - arm64
       CompatibleRuntimes:
+        - nodejs16.x
         - nodejs14.x
         - nodejs12.x
         - python3.9
@@ -28,8 +29,10 @@ Resources:
       BuildMethod: makefile
       BuildArchitecture: arm64
 
-  LayerPermission:
+  LayerVersionPermission:
     Type: AWS::Lambda::LayerVersionPermission
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Action: lambda:GetLayerVersion
       LayerVersionArn: !Ref LambdaAdapterLayerArm64

--- a/template-x86_64.yaml
+++ b/template-x86_64.yaml
@@ -9,6 +9,7 @@ Resources:
     Properties:
       ContentUri: .
       CompatibleRuntimes:
+        - nodejs16.x
         - nodejs14.x
         - nodejs12.x
         - python3.9
@@ -31,8 +32,10 @@ Resources:
       BuildMethod: makefile
       BuildArchitecture: x86_64
 
-  LayerPermission:
+  LayerVersionPermission:
     Type: AWS::Lambda::LayerVersionPermission
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Action: lambda:GetLayerVersion
       LayerVersionArn: !Ref LambdaAdapterLayerX86


### PR DESCRIPTION
keep layer version permission for old layer versions. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
