### PR TITLE
remove python3.6 from compatible runtimes for x86 layer

### DIFF
--- a/template-x86_64.yaml
+++ b/template-x86_64.yaml
@@ -15,7 +15,6 @@ Resources:
         - python3.9
         - python3.8
         - python3.7
-        - python3.6
         - ruby2.7
         - java11
         - java8.al2


### PR DESCRIPTION
This keeps the number of compatible runtimes within limits.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
