### PR TITLE
Extract logic into a library.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,5 @@
 max_width=120
+unstable_features = true
+imports_granularity = "Crate"
+reorder_imports = true
+edition = "2021"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,10 +57,12 @@ dependencies = [
  "http",
  "lambda-extension",
  "lambda_http",
- "log",
  "reqwest",
  "tokio",
  "tokio-retry",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -731,6 +733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -917,6 +937,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,12 @@ env_logger = "0.8.3"
 http = "0.2.4"
 lambda-extension = "0.6.0"
 lambda_http = "0.6.0"
-log = "0.4.14"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 tokio = { version = "1.20.0", features = ["macros", "io-util", "sync", "rt-multi-thread", "time"] }
 tokio-retry = "0.3"
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tower = "0.4.13"
 
 [[bin]]
 name = "lambda-adapter"

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,6 @@ build-LambdaAdapterLayerX86:
 build-LambdaAdapterLayerArm64:
 	cp layer/* $(ARTIFACTS_DIR)/
 	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -o $(ARTIFACTS_DIR)/extensions .
+
+fmt:
+	cargo +nightly fmt --all

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+unstable_features = true
+imports_granularity = "Crate"
+reorder_imports = true
+edition = "2021"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-unstable_features = true
-imports_granularity = "Crate"
-reorder_imports = true
-edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use lambda_extension::Extension;
 use lambda_http::{Body, Request, RequestExt, Response};
 use reqwest::{redirect, Client, Url};
@@ -112,9 +115,9 @@ impl Adapter {
 /// Implement a `Tower.Service` that sends the requests
 /// to the web server.
 impl Service<Request> for Adapter {
-    type Error = Error;
     type Response = http::Response<Body>;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Error>>>>;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     fn poll_ready(&mut self, _cx: &mut core::task::Context<'_>) -> core::task::Poll<Result<(), Self::Error>> {
         core::task::Poll::Ready(Ok(()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,210 @@
+use lambda_extension::Extension;
+use lambda_http::{Body, Request, RequestExt, Response};
+use reqwest::{redirect, Client, Url};
+use std::{env, future::Future, mem, pin::Pin, time::Duration};
+use tokio::{runtime::Handle, time::timeout};
+use tokio_retry::{strategy::FixedInterval, Retry};
+use tower::Service;
+
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Default)]
+pub struct AdapterOptions {
+    host: String,
+    port: String,
+    readiness_check_port: String,
+    readiness_check_path: String,
+    base_path: Option<String>,
+    async_init: bool,
+}
+
+impl AdapterOptions {
+    pub fn from_env() -> Self {
+        AdapterOptions {
+            host: env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
+            port: env::var("PORT").unwrap_or_else(|_| "8080".to_string()),
+            readiness_check_port: env::var("READINESS_CHECK_PORT")
+                .unwrap_or_else(|_| env::var("PORT").unwrap_or_else(|_| "8080".to_string())),
+            readiness_check_path: env::var("READINESS_CHECK_PATH").unwrap_or_else(|_| "/".to_string()),
+            base_path: env::var("REMOVE_BASE_PATH").ok(),
+            async_init: env::var("ASYNC_INIT")
+                .unwrap_or_else(|_| "false".to_string())
+                .parse()
+                .unwrap_or(false),
+        }
+    }
+}
+
+pub struct Adapter {
+    client: Client,
+    healthcheck_url: String,
+    async_init: bool,
+    ready_at_init: bool,
+    domain: Url,
+    base_path: Option<String>,
+}
+
+impl Adapter {
+    /// Create a new Adapter instance.
+    /// This function initializes a new HTTP client
+    /// to talk with the web server.
+    pub fn new(options: &AdapterOptions) -> Adapter {
+        let client = Client::builder()
+            .redirect(redirect::Policy::none())
+            .pool_idle_timeout(Duration::from_secs(4))
+            .build()
+            .unwrap();
+
+        let healthcheck_url = format!(
+            "http://{}:{}{}",
+            options.host, options.readiness_check_port, options.readiness_check_path
+        );
+
+        let domain = format!("http://{}:{}", options.host, options.port).parse().unwrap();
+
+        Adapter {
+            client,
+            healthcheck_url,
+            domain,
+            base_path: options.base_path.clone(),
+            async_init: options.async_init,
+            ready_at_init: false,
+        }
+    }
+
+    /// Switch the default HTTP client with a different one.
+    pub fn with_client(self, client: Client) -> Self {
+        Adapter { client, ..self }
+    }
+
+    /// Check if the web server has been initialized.
+    /// If `Adapter.async_init` is true, cancel this check before
+    /// Lambda's init 10s timeout, and let the server boot in the background.
+    pub async fn check_init_health(&mut self) {
+        self.ready_at_init = if self.async_init {
+            timeout(Duration::from_secs_f32(9.8), self.check_readiness())
+                .await
+                .unwrap_or_default()
+        } else {
+            self.check_readiness().await
+        };
+    }
+
+    async fn check_readiness(&self) -> bool {
+        Retry::spawn(FixedInterval::from_millis(10), || {
+            let fut = self.check_health_url();
+            async move { fut.await }
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn check_health_url(&self) -> Result<bool, std::convert::Infallible> {
+        self.client
+            .head(&self.healthcheck_url)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .or(Ok(false))
+    }
+}
+
+/// Implement a `Tower.Service` that sends the requests
+/// to the web server.
+impl Service<Request> for Adapter {
+    type Error = Error;
+    type Response = http::Response<Body>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Error>>>>;
+
+    fn poll_ready(&mut self, _cx: &mut core::task::Context<'_>) -> core::task::Poll<Result<(), Self::Error>> {
+        core::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, event: Request) -> Self::Future {
+        if self.async_init && !self.ready_at_init {
+            let handle = Handle::current();
+            handle.block_on(self.check_readiness());
+            self.ready_at_init = true;
+        }
+
+        let path = event.raw_http_path();
+        let mut path = path.as_str();
+        let (parts, body) = event.into_parts();
+
+        // strip away Base Path if environment variable REMOVE_BASE_PATH is set.
+        if let Some(base_path) = self.base_path.as_deref() {
+            path = path.trim_start_matches(base_path);
+        }
+
+        let mut app_url = self.domain.clone();
+        app_url.set_path(path);
+        app_url.set_query(parts.uri.query());
+        tracing::debug!(app_url = %app_url, "sending request to server");
+
+        let app_response = self
+            .client
+            .request(parts.method, app_url.to_string())
+            .headers(parts.headers)
+            .body(body.to_vec())
+            .send();
+
+        Box::pin(async move {
+            let app_response = app_response.await?;
+            let mut lambda_response = Response::builder();
+            let _ = mem::replace(lambda_response.headers_mut().unwrap(), app_response.headers().clone());
+
+            let status = app_response.status();
+            let body = convert_body(app_response).await?;
+            let resp = lambda_response.status(status).body(body).map_err(Box::new)?;
+
+            Ok(resp)
+        })
+    }
+}
+
+/// Register a Lambda Extension to ensure
+/// that the adapter is loaded before any Lambda function
+/// associated with it.
+pub fn register_default_extension() {
+    // register as an external extension
+    tokio::task::spawn(async move {
+        match Extension::new().with_events(&[]).run().await {
+            Ok(_) => {}
+            Err(err) => {
+                tracing::error!(err = err, "extension terminated unexpectedly");
+                panic!("extension thread execution");
+            }
+        }
+    });
+}
+
+async fn convert_body(app_response: reqwest::Response) -> Result<Body, Error> {
+    tracing::debug!(resp_headers = ?app_response.headers(), "converting response body");
+
+    if app_response.headers().get(http::header::CONTENT_ENCODING).is_some() {
+        let content = app_response.bytes().await?;
+        return Ok(Body::Binary(content.to_vec()));
+    }
+
+    match app_response.headers().get(http::header::CONTENT_TYPE) {
+        Some(value) => {
+            let content_type = value.to_str().unwrap_or_default();
+
+            if content_type.starts_with("text")
+                || content_type.starts_with("application/json")
+                || content_type.starts_with("application/javascript")
+                || content_type.starts_with("application/xml")
+            {
+                Ok(Body::Text(app_response.text().await?))
+            } else {
+                let content = app_response.bytes().await?;
+                if content.is_empty() {
+                    Ok(Body::Empty)
+                } else {
+                    Ok(Body::Binary(content.to_vec()))
+                }
+            }
+        }
+        None => Ok(Body::Text(app_response.text().await?)),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,169 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use lambda_extension::{service_fn as extension_handler, Extension};
-use lambda_http::{service_fn as http_handler, Body, Request, RequestExt, Response};
-use log::*;
-use reqwest::{redirect, Client};
-use std::time::Duration;
-use std::{env, future, mem};
-use tokio::time::timeout;
-use tokio_retry::{strategy::FixedInterval, Retry};
-
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-struct AdapterOptions {
-    host: String,
-    port: String,
-    readiness_check_port: String,
-    readiness_check_path: String,
-    base_path: Option<String>,
-    async_init: bool,
-}
+use aws_lambda_adapter::{Adapter, AdapterOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    env_logger::init();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
 
-    // setup config options from environment variables
-    let options = &AdapterOptions {
-        host: env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        port: env::var("PORT").unwrap_or_else(|_| "8080".to_string()),
-        readiness_check_port: env::var("READINESS_CHECK_PORT")
-            .unwrap_or_else(|_| env::var("PORT").unwrap_or_else(|_| "8080".to_string())),
-        readiness_check_path: env::var("READINESS_CHECK_PATH").unwrap_or_else(|_| "/".to_string()),
-        base_path: env::var("REMOVE_BASE_PATH").ok(),
-        async_init: env::var("ASYNC_INIT")
-            .unwrap_or_else(|_| "false".to_string())
-            .parse()
-            .unwrap_or(false),
-    };
+    let options = AdapterOptions::from_env();
+    aws_lambda_adapter::register_default_extension();
 
-    // register as an external extension
-    tokio::task::spawn(async move {
-        Extension::new()
-            .with_events(&[])
-            .with_events_processor(extension_handler(|_| async { Ok::<(), Error>(()) }))
-            .run()
-            .await
-            .expect("extension thread error");
-    });
+    let mut adapter = Adapter::new(&options);
+    adapter.check_init_health().await;
 
-    // check if the application is ready
-    let is_ready = if options.async_init {
-        timeout(Duration::from_secs_f32(9.8), check_readiness(options))
-            .await
-            .is_ok()
-    } else {
-        check_readiness(options).await
-    };
-
-    // start lambda runtime
-    let http_client = &Client::builder()
-        .redirect(redirect::Policy::none())
-        .pool_idle_timeout(Duration::from_secs(4))
-        .build()
-        .unwrap();
-    let mut first_invoke = true;
-    lambda_http::run(http_handler(|event: Request| {
-        let is_app_ready = if first_invoke {
-            first_invoke = false;
-            is_ready
-        } else {
-            true // the app must be ready after the first invoke
-        };
-        async move { http_proxy_handler(event, http_client, options, is_app_ready).await }
-    }))
-    .await?;
-    Ok(())
-}
-
-async fn check_readiness(options: &AdapterOptions) -> bool {
-    Retry::spawn(FixedInterval::from_millis(10), || {
-        let readiness_check_url = format!(
-            "http://{}:{}{}",
-            options.host, options.readiness_check_port, options.readiness_check_path
-        );
-        match reqwest::blocking::get(readiness_check_url) {
-            Ok(response) if { response.status().is_success() } => future::ready(Ok(())),
-            _ => future::ready(Err::<(), i32>(-1)),
-        }
-    })
-    .await
-    .is_ok()
-}
-
-async fn http_proxy_handler(
-    event: Request,
-    http_client: &Client,
-    options: &AdapterOptions,
-    is_app_ready: bool,
-) -> Result<Response<Body>, Error> {
-    // continue checking readiness if async_init is configured and the app is not ready
-    if options.async_init && !is_app_ready {
-        check_readiness(options).await;
-    }
-
-    let raw_path = event.raw_http_path();
-    let (parts, body) = event.into_parts();
-
-    // construct the path and query without APIGW stage
-    let mut path_and_query = match parts.uri.query() {
-        Some(query) => format!("{}?{}", raw_path, query),
-        None => raw_path,
-    };
-
-    // strip away Base Path if environment variable REMOVE_BASE_PATH is set.
-    if options.base_path.is_some() {
-        if let Some(value) = path_and_query.strip_prefix(options.base_path.as_ref().unwrap()) {
-            path_and_query = value.to_string();
-        };
-    }
-    let app_url = format!("http://{}:{}{}", options.host, options.port, path_and_query);
-    debug!("app_url is {:#?}", app_url);
-
-    let app_response = http_client
-        .request(parts.method, app_url)
-        .headers(parts.headers)
-        .body(body.to_vec())
-        .send()
-        .await?;
-
-    let mut lambda_response = Response::builder();
-    let _ = mem::replace(lambda_response.headers_mut().unwrap(), app_response.headers().clone());
-    Ok(lambda_response
-        .status(app_response.status())
-        .body(convert_body(app_response).await?)
-        .expect("failed to send response"))
-}
-
-async fn convert_body(app_response: reqwest::Response) -> Result<Body, Error> {
-    debug!("app response headers are {:#?}", app_response.headers());
-
-    if app_response.headers().get(http::header::CONTENT_ENCODING).is_some() {
-        let content = app_response.bytes().await?;
-        return Ok(Body::Binary(content.to_vec()));
-    }
-
-    match app_response.headers().get(http::header::CONTENT_TYPE) {
-        Some(value) => {
-            let content_type = value.to_str().unwrap_or_default();
-
-            if content_type.starts_with("text")
-                || content_type.starts_with("application/json")
-                || content_type.starts_with("application/javascript")
-                || content_type.starts_with("application/xml")
-            {
-                Ok(Body::Text(app_response.text().await?))
-            } else {
-                let content = app_response.bytes().await?;
-                if content.is_empty() {
-                    Ok(Body::Empty)
-                } else {
-                    Ok(Body::Binary(content.to_vec()))
-                }
-            }
-        }
-        None => Ok(Body::Text(app_response.text().await?)),
-    }
+    lambda_http::run(adapter).await
 }


### PR DESCRIPTION
This change moves the main codebase into a library to help with reusability.

This way the adapter can be used independently of the main app.

This change also replaces the `log` crate with `tracing`, which is more widely used in the lambda echosystem.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
