### PR TITLE
Update lambda_http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-lambda-adapter"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "env_logger",
  "http",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a540048486ccfaa407ef7d2b50b7ff7b8c18abfbf351731a4ff7ccd165fc43fa"
+checksum = "cf9542aeed47b5ac3484b290b78f0af4d35739886dfaaa85da3151327a8ce47a"
 dependencies = [
  "aws_lambda_events",
  "base64",
@@ -410,6 +410,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-lambda-adapter"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Harold Sun <sunhua@amazon.com>"]
 edition = "2021"
 
@@ -8,7 +8,7 @@ edition = "2021"
 env_logger = "0.8.3"
 http = "0.2.4"
 lambda-extension = "0.6.0"
-lambda_http = "0.6.0"
+lambda_http = "0.6.1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 tokio = { version = "1.20.0", features = ["macros", "io-util", "sync", "rt-multi-thread", "time"] }
 tokio-retry = "0.3"


### PR DESCRIPTION
This new version fixes issues with http paths with spaces in them.

This PR depends on https://github.com/awslabs/aws-lambda-rust-runtime/pull/526

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
