### PR TITLE
Hide run instruction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::time::timeout;
 use tokio_retry::{strategy::FixedInterval, Retry};
 use tower::Service;
 
-type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub use lambda_http::Error;
 
 #[derive(Default)]
 pub struct AdapterOptions {
@@ -110,6 +110,10 @@ impl Adapter {
     async fn check_readiness(&self) -> bool {
         let url = self.healthcheck_url.clone();
         is_web_ready(&url).await
+    }
+
+    pub async fn run(self) -> Result<(), Error> {
+        lambda_http::run(self).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ impl Adapter {
         is_web_ready(&url).await
     }
 
+    /// Run the adapter to take events from Lambda.
     pub async fn run(self) -> Result<(), Error> {
         lambda_http::run(self).await
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
-use lambda_web_adapter::{Adapter, AdapterOptions};
+use lambda_web_adapter::{Adapter, AdapterOptions, Error};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 
 #[tokio::main]
@@ -18,6 +16,5 @@ async fn main() -> Result<(), Error> {
 
     let mut adapter = Adapter::new(&options);
     adapter.check_init_health().await;
-
-    lambda_http::run(adapter).await
+    adapter.run().await
 }


### PR DESCRIPTION
Remove the dependency of lambda_http to run the adapter, so people don't have to import that crate only to call lambda_http::run.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
