### PR TITLE
Add more debug information for req/res transformations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ version = "0.4.0"
 dependencies = [
  "env_logger",
  "http",
+ "http-body",
  "lambda-extension",
  "lambda_http",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio-retry = "0.3"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tower = "0.4.13"
+http-body = "0.4.5"
 
 [[bin]]
 name = "lambda-adapter"


### PR DESCRIPTION
This helps debugging when the transformation between lambda and the server doesn't work correctly.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
