### PR TITLE
Add login to ECR on flask-zip sample

### DIFF
--- a/examples/flask-zip/README.md
+++ b/examples/flask-zip/README.md
@@ -19,6 +19,7 @@ To get more information of Wrapper script, please read Lambda documentation [her
 Run the following commands to build and deploy the application to lambda. 
 
 ```bash
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 sam build --use-container
 sam deploy --guided
 ```


### PR DESCRIPTION
*Issue #, if available:*

`sam build --use-container` fetch a docker image from public.ecr.aws, login is required otherwise raise an error during the pull

> raise DockerImagePullFailedException(
> samcli.local.docker.manager.DockerImagePullFailedException: Could not find public.ecr.aws/sam/build-python3.9:latest-x86_64 image locally and failed to pull it from docker.
> 

*Description of changes:*

Add docker login to the documentation.
