### PR TITLE
upgrade to lambda_http v0.7.1 to pass correct x-ray trace id header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92800e377a35109541e00ccb7cbf4026c44b2987e5ecdb2233aecc115f20ca7"
+checksum = "e99edb20005e6456db8f1bb5abec3cf7787640b456dda195c1a3216ec4397ce8"
 dependencies = [
  "aws_lambda_events",
  "base64",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "lambda_web_adapter"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["examples"]
 [dependencies]
 http = "0.2.4"
 lambda-extension = "0.7.0"
-lambda_http = "0.7.0"
+lambda_http = "0.7.1"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 tokio = { version = "1.20.0", features = ["macros", "io-util", "sync", "rt-multi-thread", "time"] }
 tokio-retry = "0.3"


### PR DESCRIPTION
upgrade to lambda_http v0.7.1 to pass correct x-ray trace id header

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
