### PR TITLE
relax readiness check for HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ When a new Lambda Execution Environment starts up, Lambda Web Adapter will boot 
 
 By default, Lambda Web Adapter will send HTTP GET requests to the web application at `http://127.0.0.1:8080/`. The port and path can be customized with two environment variables: `READINESS_CHECK_PORT` and `READINESS_CHECK_PATH`.  
 
-Lambda Web Adapter will retry this request every 10 milliseconds until the web application returns a successful response (http status code 2xx) or the function times out. 
+Lambda Web Adapter will retry this request every 10 milliseconds until the web application returns an HTTP response (any status code) or the function times out. 
 
 In addition, you can configure the adapter to preform readiness check with TCP connect, by setting `READINESS_CHECK_PROTOCOL` to `tcp`. 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,8 +267,8 @@ async fn is_web_ready(url: &Url, protocol: &Protocol) -> bool {
 async fn check_web_readiness(url: &Url, protocol: &Protocol) -> Result<(), i8> {
     match protocol {
         Protocol::Http => match reqwest::get(url.as_str()).await {
-            Ok(response) if { response.status().is_success() } => Ok(()),
-            _ => Err(-1),
+            Ok(_) => Ok(()),
+            Err(_) => Err(-1),
         },
         Protocol::Tcp => match TcpStream::connect(format!("{}:{}", url.host().unwrap(), url.port().unwrap())).await {
             Ok(_) => Ok(()),


### PR DESCRIPTION
Pass readiness check if the web app gives an HTTP response (any status code)

This is based on the feedback from [awslabs/aws-lambda-go-api-proxy/#143](https://github.com/awslabs/aws-lambda-go-api-proxy/issues/143)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
