### PR TITLE
rewrite extension client and upgrade tokio

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,3 @@
 max_width=120
-unstable_features = true
-imports_granularity = "Crate"
 reorder_imports = true
 edition = "2021"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,12 +324,9 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "winapi",
 ]
 
 [[package]]
@@ -597,7 +594,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -845,26 +842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lambda-extension"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee60da69c68d2196f2ec8b46a3a7bd4a6bba3148dfa7c882b42c06d62c25045"
-dependencies = [
- "async-stream",
- "bytes",
- "chrono",
- "http",
- "hyper",
- "lambda_runtime_api_client",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "lambda_http"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +903,6 @@ dependencies = [
  "http",
  "httpmock",
  "hyper",
- "lambda-extension",
  "lambda_http",
  "mime",
  "tokio",
@@ -1031,7 +1007,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.36.1",
 ]
 
@@ -1543,17 +1519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,9 +1544,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1589,12 +1554,11 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1640,7 +1604,6 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1798,12 +1761,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ exclude = ["examples"]
 [dependencies]
 http = "0.2"
 hyper = { version = "0.14", features = ["client"] }
-lambda-extension = "0.7.0"
 lambda_http = "0.7.2"
-tokio = { version = "1.20.0", features = [
+tokio = { version = "1.24", features = [
     "macros",
     "io-util",
     "sync",

--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ build-LambdaAdapterLayerArm64:
 	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -o $(ARTIFACTS_DIR)/extensions .
 
 fmt:
-	cargo +nightly fmt --all
+	cargo fmt --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ impl Adapter {
         // register as an external extension
         tokio::task::spawn(async move {
             let aws_lambda_runtime_api: String =
-                env::var("aws_lambda_runtime_api").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
+                env::var("AWS_LAMBDA_RUNTIME_API").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
             let client = hyper::Client::new();
             let register_req = hyper::Request::builder()
                 .method(Method::POST)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@ use std::{
 use encoding_rs::{Encoding, UTF_8};
 use http::{
     header::{HeaderName, HeaderValue},
-    Uri,
+    Method, StatusCode, Uri,
 };
 use hyper::{
     body::HttpBody,
     client::{Client, HttpConnector},
+    Body,
 };
-use lambda_extension::Extension;
 use lambda_http::aws_lambda_events::serde_json;
 pub use lambda_http::Error;
 use lambda_http::{Body as LambdaBody, Request, RequestExt, Response};
@@ -137,13 +137,31 @@ impl Adapter {
     pub fn register_default_extension(&self) {
         // register as an external extension
         tokio::task::spawn(async move {
-            match Extension::new().with_events(&[]).run().await {
-                Ok(_) => {}
-                Err(err) => {
-                    tracing::error!(err = err, "extension terminated unexpectedly");
-                    panic!("extension thread execution");
-                }
+            let aws_lambda_runtime_api: String =
+                env::var("aws_lambda_runtime_api").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
+            let client = hyper::Client::new();
+            let register_req = hyper::Request::builder()
+                .method(Method::POST)
+                .uri(format!("http://{aws_lambda_runtime_api}/2020-01-01/extension/register"))
+                .header("Lambda-Extension-Name", "lambda-adapter")
+                .body(Body::from("{ \"events\": [] }"))
+                .unwrap();
+            let register_res = client.request(register_req).await.unwrap();
+            if register_res.status() != StatusCode::OK {
+                panic!("extension registration failure");
             }
+            let next_req = hyper::Request::builder()
+                .method(Method::GET)
+                .uri(format!(
+                    "http://{aws_lambda_runtime_api}/2020-01-01/extension/event/next"
+                ))
+                .header(
+                    "Lambda-Extension-Identifier",
+                    register_res.headers().get("Lambda-Extension-Identifier").unwrap(),
+                )
+                .body(Body::empty())
+                .unwrap();
+            client.request(next_req).await.unwrap();
         });
     }
 

--- a/tests/integ_tests.rs
+++ b/tests/integ_tests.rs
@@ -8,10 +8,9 @@ use httpmock::{
     Method::{DELETE, GET, POST, PUT},
     MockServer,
 };
-use lambda_extension::Service;
-
 use lambda_http::Body;
 use lambda_web_adapter::{Adapter, AdapterOptions, Protocol};
+use tower::Service;
 
 #[test]
 fn test_adapter_options_from_env() {


### PR DESCRIPTION
replace lambda-extension crate with inline extension client to reduce binary size by another 1MB. 

```
-rwxr-xr-x  1 sunhua  staff   3.7M Jan  7 13:22 target/release/lambda-adapter
```

Upgrade tokio to 1.24 for improved performance


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
