### PR TITLE
Update pipeline to pull adapter images from private ecr repo during e2e test

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -352,7 +352,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --role-arn ${BETA_CLOUDFORMATION_EXECUTION_ROLE}
 
-  integration-test:
+  e2e-test:
     if:  ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
     needs: [deploy-beta]
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -154,6 +154,27 @@ jobs:
           name: packaged-beta-arm64.yaml
           path: packaged-beta-arm64.yaml
 
+      - name: Create and push the x86_64 docker image to beta ecr repo
+        run: |
+          tar -c -C build-x86_64/LambdaAdapterLayerX86 . | docker import - 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-x86_64
+          aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com
+          docker push 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-x86_64
+
+      - name: Create and push the arm64 docker image to beta ecr repo
+        run: |
+          tar -c -C build-arm64/LambdaAdapterLayerArm64 . | docker import - 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-aarch64
+          aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com
+          docker push 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-aarch64
+
+      - name: create and push the multi-arch manifest to beta ecr repo
+        run: |
+          docker manifest create 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest \
+              477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-x86_64 \
+              477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-aarch64
+          docker manifest annotate --arch arm64 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest \
+              477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest-aarch64
+          docker manifest push 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest
+
 
   package-gamma:
     if:  ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
@@ -397,7 +418,7 @@ jobs:
         run: |
           sam delete --no-prompts --region ${BETA_REGION} --stack-name ${BETA_STACK_NAME}-oci-x86 
 
-      - name: deploy the zip x86 integration test stacks for the beta environment
+      - name: remove the zip x86 integration test stacks
         working-directory: ./tests/e2e/fixtures/go-httpbin-zip
         run: |
           sam delete --no-prompts --region ${BETA_REGION} --stack-name ${BETA_STACK_NAME}-zip-x86 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -377,6 +377,7 @@ jobs:
       - name: deploy the oci x86 integration test stacks for the beta environment
         working-directory: ./tests/e2e/fixtures/go-httpbin
         run: |
+          aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin 477159140107.dkr.ecr.ap-northeast-1.amazonaws.com
           sam build
           sam deploy --stack-name ${BETA_STACK_NAME}-oci-x86 \
             --capabilities CAPABILITY_IAM \

--- a/template-arm64.yaml
+++ b/template-arm64.yaml
@@ -38,6 +38,14 @@ Resources:
       LayerVersionArn: !Ref LambdaAdapterLayerArm64
       Principal: '*'
 
+  LambdaAdapterLayerArm64Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /lambda-web-adapter/layer/arm64/latest
+      Description: 'Layer ARN for the latest Lambda Web Adapter Arm64 Layer'
+      Type: String
+      Value: !Ref LambdaAdapterLayerArm64
+
 Outputs:
   LambdaAdapterLayerArm64Arn:
     Description: "arn for LambdaAdapterLayerArm64"

--- a/template-x86_64.yaml
+++ b/template-x86_64.yaml
@@ -40,6 +40,14 @@ Resources:
       LayerVersionArn: !Ref LambdaAdapterLayerX86
       Principal: '*'
 
+  LambdaAdapterLayerX86Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /lambda-web-adapter/layer/x86_64/latest
+      Description: 'Layer ARN for the latest Lambda Web Adapter X86_64 Layer'
+      Type: String
+      Value: !Ref LambdaAdapterLayerX86
+
 Outputs:
   LambdaAdapterLayerX86Arn:
     Description: "arn for LambdaAdapterLayerX86"

--- a/tests/e2e/fixtures/go-httpbin-zip/template.yaml
+++ b/tests/e2e/fixtures/go-httpbin-zip/template.yaml
@@ -21,6 +21,9 @@ Parameters:
   Route53HostedZoneId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /lambda-web-adapter/e2e/hostedzoneid
+  AdapterLayerArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /lambda-web-adapter/layer/x86_64/latest
 
 Globals:
   Function:
@@ -59,7 +62,7 @@ Resources:
       Runtime: provided.al2
       MemorySize: 256
       Layers:
-        - {{resolve:ssm:/lambda-web-adapter/layer/x86_64/latest}}
+        - !Ref AdapterLayerArn
       Events:
         HttpAPIEvent:
           Type: HttpApi

--- a/tests/e2e/fixtures/go-httpbin-zip/template.yaml
+++ b/tests/e2e/fixtures/go-httpbin-zip/template.yaml
@@ -59,7 +59,7 @@ Resources:
       Runtime: provided.al2
       MemorySize: 256
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:11
+        - {{resolve:ssm:/lambda-web-adapter/layer/x86_64/latest}}
       Events:
         HttpAPIEvent:
           Type: HttpApi

--- a/tests/e2e/fixtures/go-httpbin/app/Dockerfile
+++ b/tests/e2e/fixtures/go-httpbin/app/Dockerfile
@@ -1,3 +1,3 @@
 FROM mccutchen/go-httpbin:v2.4.1
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.6.1 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=477159140107.dkr.ecr.ap-northeast-1.amazonaws.com/awsguru/aws-lambda-adapter:latest /lambda-adapter /opt/extensions/lambda-adapter
 CMD ["/bin/go-httpbin"]


### PR DESCRIPTION
Update pipeline to pull adapter images from private ecr repo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
