### PR TITLE
Optional gzip compression of responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +496,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -966,6 +991,7 @@ dependencies = [
 name = "lambda_web_adapter"
 version = "0.6.1"
 dependencies = [
+ "flate2",
  "http",
  "http-body 0.4.5",
  "http-body-util",
@@ -1066,6 +1092,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["examples"]
 http = "0.2"
 hyper = { version = "0.14", features = ["client"] }
 lambda_http = "0.7.3"
+flate2 = "1.0.25"
 tokio = { version = "1.24", features = [
     "macros",
     "io-util",

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ After passing readiness check, Lambda Web Adapter will start Lambda Runtime and 
 
 The readiness check port/path and traffic port can be configured using environment variables. These environment variables can be defined either within docker file or as Lambda function configuration.
 
-| Environment Variable     | Description                                                          | Default |
-|--------------------------|----------------------------------------------------------------------|---------|
-| PORT                     | traffic port                                                         | "8080"  |
-| READINESS_CHECK_PORT     | readiness check port, default to the traffic port                    | PORT    |
-| READINESS_CHECK_PATH     | readiness check path                                                 | "/"     |
-| READINESS_CHECK_PROTOCOL | readiness check protocol: "http" or "tcp", default is "http"         | "http"  |
-| ASYNC_INIT               | enable asynchronous initialization for long initialization functions | "false" |
-| REMOVE_BASE_PATH         | (optional) the base path to be removed from request path             | None    |
+| Environment Variable       | Description                                                          | Default |
+| -------------------------- | -------------------------------------------------------------------- | ------- |
+| PORT                       | traffic port                                                         | "8080"  |
+| READINESS_CHECK_PORT       | readiness check port, default to the traffic port                    | PORT    |
+| READINESS_CHECK_PATH       | readiness check path                                                 | "/"     |
+| READINESS_CHECK_PROTOCOL   | readiness check protocol: "http" or "tcp", default is "http"         | "http"  |
+| ASYNC_INIT                 | enable asynchronous initialization for long initialization functions | "false" |
+| REMOVE_BASE_PATH           | (optional) the base path to be removed from request path             | None    |
+| AWS_LWA_ENABLE_COMPRESSION | (optional) enable gzip compression for response body                 | "false" |
 
 **ASYNC_INIT** Lambda managed runtimes offer up to 10 seconds for function initialization. During this period of time, Lambda functions have burst of CPU to accelerate initialization, and it is free. 
 If a lambda function couldn't complete the initialization within 10 seconds, Lambda will restart the function, and bill for the initialization. 
@@ -84,6 +85,10 @@ To help functions to use this 10 seconds free initialization time and avoid the 
 When this feature is enabled, Lambda Web Adapter performs readiness check up to 9.8 seconds. If the web app is not ready by then, 
 Lambda Web Adapter signals to Lambda service that the init is completed, and continues readiness check in the handler. 
 This feature is disabled by default. Enable it by setting environment variable `ASYNC_INIT` to `true`. 
+
+**LAMBDA_ADAPTER_COMPRESSION** Lambda Web Adapter supports gzip compression for response body. This feature is disabled by default. Enable it by setting environment variable `AWS_LWA_ENABLE_COMPRESSION` to `true`.
+When enabled, Lambda Web Adapter will check the `Accept-Encoding` header in the request, and compress the response body if the header contains `gzip`, if the response body is not already compressed, and if the `Content-Type` starts with `text/` or is `application/javascript`, `application/json`, `application/json+ld`, `application/xml`, `application/xhtml+xml`, `application/x-javascript`, or `image/svg+xml`.
+Note that the `Content-Length` header will be set to the compressed size, not the original size.
 
 **REMOVE_BASE_PATH** - The value of this environment variable tells the adapter whether the application is running under a base path.
 For example, you could have configured your API Gateway to have a /orders/{proxy+} and a /catalog/{proxy+} resource.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When this feature is enabled, Lambda Web Adapter performs readiness check up to 
 Lambda Web Adapter signals to Lambda service that the init is completed, and continues readiness check in the handler. 
 This feature is disabled by default. Enable it by setting environment variable `ASYNC_INIT` to `true`. 
 
-**LAMBDA_ADAPTER_COMPRESSION** Lambda Web Adapter supports gzip compression for response body. This feature is disabled by default. Enable it by setting environment variable `AWS_LWA_ENABLE_COMPRESSION` to `true`.
+**AWS_LWA_ENABLE_COMPRESSION** Lambda Web Adapter supports gzip compression for response body. This feature is disabled by default. Enable it by setting environment variable `AWS_LWA_ENABLE_COMPRESSION` to `true`.
 When enabled, Lambda Web Adapter will check the `Accept-Encoding` header in the request, and compress the response body if the header contains `gzip`, if the response body is not already compressed, and if the `Content-Type` starts with `text/` or is `application/javascript`, `application/json`, `application/json+ld`, `application/xml`, `application/xhtml+xml`, `application/x-javascript`, or `image/svg+xml`.
 Note that the `Content-Length` header will be set to the compressed size, not the original size.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
         Arc,
     },
     time::Duration,
+    io::prelude::*,
 };
 
 use http::{
@@ -17,6 +18,7 @@ use http::{
     Method, StatusCode, Uri,
 };
 use hyper::{
+    body,
     body::HttpBody,
     client::{Client, HttpConnector},
     Body,
@@ -24,6 +26,8 @@ use hyper::{
 use lambda_http::aws_lambda_events::serde_json;
 pub use lambda_http::Error;
 use lambda_http::{Request, RequestExt, Response};
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 use tokio_retry::{strategy::FixedInterval, Retry};
@@ -60,6 +64,7 @@ pub struct AdapterOptions {
     pub readiness_check_protocol: Protocol,
     pub base_path: Option<String>,
     pub async_init: bool,
+    pub compression: bool,
 }
 
 impl AdapterOptions {
@@ -79,6 +84,10 @@ impl AdapterOptions {
                 .unwrap_or_else(|_| "false".to_string())
                 .parse()
                 .unwrap_or(false),
+            compression: env::var("COMPRESSION")
+                .unwrap_or_else(|_| "false".to_string())
+                .parse()
+                .unwrap_or(false),
         }
     }
 }
@@ -92,6 +101,7 @@ pub struct Adapter {
     ready_at_init: Arc<AtomicBool>,
     domain: Uri,
     base_path: Option<String>,
+    compression: bool,
 }
 
 impl Adapter {
@@ -120,6 +130,7 @@ impl Adapter {
             base_path: options.base_path.clone(),
             async_init: options.async_init,
             ready_at_init: Arc::new(AtomicBool::new(false)),
+            compression: options.compression,
         }
     }
 
@@ -206,6 +217,12 @@ impl Adapter {
             path = path.trim_start_matches(base_path);
         }
 
+        let accepts_gzip = parts
+            .headers
+            .get("accept-encoding")
+            .map(|v| v.to_str().unwrap_or_default().contains("gzip"))
+            .unwrap_or_default();
+
         let mut req_headers = parts.headers;
 
         // include request context in http header "x-amzn-request-context"
@@ -236,6 +253,49 @@ impl Adapter {
         let app_response = self.client.request(request).await?;
         tracing::debug!(status = %app_response.status(), body_size = app_response.body().size_hint().lower(),
             app_headers = ?app_response.headers().clone(), "responding to lambda event");
+
+        let response_compressed = app_response.headers().get("content-encoding").is_some();
+
+        let content_type = if let Some(content_type) = app_response.headers().get("content-type") {
+            content_type.to_str().unwrap()
+        } else {
+            ""
+        };
+
+        let compressable_content_type =
+            content_type.starts_with("text/")
+            || content_type.starts_with("application/json")
+            || content_type.starts_with("application/javascript")
+            || content_type.starts_with("application/xml")
+            || content_type.starts_with("application/xhtml+xml")
+            || content_type.starts_with("application/x-javascript")
+            || content_type.starts_with("application/xml");
+
+        // Gzip the response if the client accepts it
+        let app_response = if !self.compression {
+            app_response
+        } else if accepts_gzip && !response_compressed && compressable_content_type {
+            let (parts, body) = app_response.into_parts();
+            let mut builder = hyper::Response::builder().status(parts.status).version(parts.version);
+            if let Some(headers) = builder.headers_mut() {
+                // Remove the content-length header as we can't overwrite it after setting it
+                let mut clean_headers = parts.headers.clone();
+                clean_headers.remove(http::header::CONTENT_LENGTH);
+
+                headers.extend(clean_headers);
+            }
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(& body::to_bytes(body).await.unwrap())?;
+            let gzipped_body = encoder.finish()?;
+
+            builder
+                // Write the new content-length header
+                .header(http::header::CONTENT_LENGTH, gzipped_body.len().to_string())
+                .header("content-encoding", "gzip")
+                .body(hyper::Body::from(gzipped_body))?
+        } else {
+            app_response
+        };
 
         Ok(app_response)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl AdapterOptions {
                 .unwrap_or_else(|_| "false".to_string())
                 .parse()
                 .unwrap_or(false),
-            compression: env::var("COMPRESSION")
+            compression: env::var("AWS_LWA_ENABLE_COMPRESSION")
                 .unwrap_or_else(|_| "false".to_string())
                 .parse()
                 .unwrap_or(false),
@@ -264,8 +264,9 @@ impl Adapter {
 
         let compressable_content_type = content_type.starts_with("text/")
             || content_type.starts_with("application/json")
+            || content_type.starts_with("application/ld+json")
             || content_type.starts_with("application/javascript")
-            || content_type.starts_with("application/xml")
+            || content_type.starts_with("image/svg+xml")
             || content_type.starts_with("application/xhtml+xml")
             || content_type.starts_with("application/x-javascript")
             || content_type.starts_with("application/xml");

--- a/tests/e2e/fixtures/go-httpbin-zip/template.yaml
+++ b/tests/e2e/fixtures/go-httpbin-zip/template.yaml
@@ -61,6 +61,9 @@ Resources:
       Handler: bootstrap
       Runtime: provided.al2
       MemorySize: 256
+      Environment:
+        Variables:
+          AWS_LWA_ENABLE_COMPRESSION: 'true'
       Layers:
         - !Ref AdapterLayerArn
       Events:

--- a/tests/e2e/fixtures/go-httpbin/template.yaml
+++ b/tests/e2e/fixtures/go-httpbin/template.yaml
@@ -56,6 +56,9 @@ Resources:
     Properties:
       PackageType: Image
       MemorySize: 256
+      Environment:
+        Variables:
+          AWS_LWA_ENABLE_COMPRESSION: 'true'
       Events:
         HttpAPIEvent:
           Type: HttpApi

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1,9 +1,12 @@
+use flate2::read::GzDecoder;
 use http::Uri;
 use hyper::{Body, Client, Method, Request};
 use hyper_tls::HttpsConnector;
 use lambda_http::aws_lambda_events::serde_json;
 use lambda_http::aws_lambda_events::serde_json::Value;
 use std::env;
+use std::io;
+use std::io::prelude::*;
 
 fn get_endpoints() -> Vec<Option<String>> {
     let configurations = [
@@ -18,6 +21,13 @@ fn get_endpoints() -> Vec<Option<String>> {
     ];
 
     configurations.iter().map(|e| env::var(e).ok()).collect()
+}
+
+fn decode_reader(bytes: &Vec<u8>) -> io::Result<String> {
+    let mut gz = GzDecoder::new(&bytes[..]);
+    let mut s = String::new();
+    gz.read_to_string(&mut s)?;
+    Ok(s)
 }
 
 #[ignore]
@@ -85,6 +95,36 @@ async fn test_http_query_params() {
             assert!(body["args"]["fizz"][0].is_string());
             assert_eq!(Some("buzz"), body["args"]["fizz"][0].as_str());
             assert_eq!(Some("bar"), body["args"]["foo"][0].as_str());
+        }
+    }
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_http_compress() {
+    for endpoint in get_endpoints().iter() {
+        if let Some(endpoint) = endpoint {
+            let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+            let parts = endpoint.parse::<Uri>().unwrap().into_parts();
+            let uri = Uri::builder()
+                .scheme(parts.scheme.unwrap())
+                .authority(parts.authority.unwrap())
+                .path_and_query("/html")
+                .build()
+                .unwrap();
+            let req = Request::builder()
+                .method(Method::GET)
+                .header("accept-encoding", "gzip")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            let resp = client.request(req).await.unwrap();
+            let (parts, body) = resp.into_parts();
+            let body_bytes = hyper::body::to_bytes(body).await.unwrap();
+            let body = decode_reader(&body_bytes.to_vec()).unwrap();
+
+            assert_eq!(200, parts.status.as_u16());
+            assert!(body.contains("<html>"));
         }
     }
 }

--- a/tests/integ_tests.rs
+++ b/tests/integ_tests.rs
@@ -280,7 +280,9 @@ async fn test_http_compress() {
 
     // // Call the adapter service with basic request
     let req = LambdaEventBuilder::new()
-        .with_path("/hello").with_header("accept-encoding", "gzip").build();
+        .with_path("/hello")
+        .with_header("accept-encoding", "gzip")
+        .build();
     let response = adapter.call(req.into()).await.expect("Request failed");
 
     // Assert endpoint was called once
@@ -290,8 +292,10 @@ async fn test_http_compress() {
     assert_eq!(200, response.status());
     assert_eq!(response.headers().get("content-length").unwrap(), "48"); // uncompressed: 59
     assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
-    assert_eq!("Hello World Hello World Hello World Hello World Hello World",
-        compressed_body_to_string(response).await);
+    assert_eq!(
+        "Hello World Hello World Hello World Hello World Hello World",
+        compressed_body_to_string(response).await
+    );
 }
 
 #[tokio::test]
@@ -319,7 +323,9 @@ async fn test_http_compress_disallowed_type() {
 
     // // Call the adapter service with basic request
     let req = LambdaEventBuilder::new()
-        .with_path("/hello").with_header("accept-encoding", "gzip").build();
+        .with_path("/hello")
+        .with_header("accept-encoding", "gzip")
+        .build();
     let response = adapter.call(req.into()).await.expect("Request failed");
 
     // Assert endpoint was called once
@@ -329,14 +335,19 @@ async fn test_http_compress_disallowed_type() {
     assert_eq!(200, response.status());
     assert_eq!(response.headers().get("content-length").unwrap(), "59"); // uncompressed: 59
     assert_eq!(response.headers().contains_key("content-encoding"), false);
-    assert_eq!("Hello World Hello World Hello World Hello World Hello World", body_to_string(response).await);
+    assert_eq!(
+        "Hello World Hello World Hello World Hello World Hello World",
+        body_to_string(response).await
+    );
 }
 
 #[tokio::test]
 async fn test_http_compress_already_compressed() {
     unsafe {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(b"Hello World Hello World Hello World Hello World Hello World").unwrap();
+        encoder
+            .write_all(b"Hello World Hello World Hello World Hello World Hello World")
+            .unwrap();
         let gzipped_body = encoder.finish();
 
         // Turn the vector into a fake string
@@ -346,9 +357,7 @@ async fn test_http_compress_already_compressed() {
         let app_server = MockServer::start();
         let hello = app_server.mock(|when, then| {
             when.method(GET).path("/hello");
-            then.status(200)
-                .header("content-encoding", "gzip")
-                .body(gzipped_body);
+            then.status(200).header("content-encoding", "gzip").body(gzipped_body);
         });
 
         // Initialize adapter
@@ -365,7 +374,9 @@ async fn test_http_compress_already_compressed() {
 
         // Call the adapter service with basic request
         let req = LambdaEventBuilder::new()
-            .with_path("/hello").with_header("accept-encoding", "gzip").build();
+            .with_path("/hello")
+            .with_header("accept-encoding", "gzip")
+            .build();
         let response = adapter.call(req.into()).await.expect("Request failed");
 
         // Assert endpoint was called once
@@ -375,8 +386,10 @@ async fn test_http_compress_already_compressed() {
         assert_eq!(200, response.status());
         assert_eq!(response.headers().get("content-length").unwrap(), "48"); // uncompressed: 59
         assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
-        assert_eq!("Hello World Hello World Hello World Hello World Hello World",
-            compressed_body_to_string(response).await);
+        assert_eq!(
+            "Hello World Hello World Hello World Hello World Hello World",
+            compressed_body_to_string(response).await
+        );
     }
 }
 
@@ -395,4 +408,4 @@ fn decode_reader(bytes: &Vec<u8>) -> io::Result<String> {
     let mut s = String::new();
     gz.read_to_string(&mut s)?;
     Ok(s)
- }
+}

--- a/tests/integ_tests.rs
+++ b/tests/integ_tests.rs
@@ -1,6 +1,8 @@
 pub mod events;
 
 use std::env;
+use std::io;
+use std::io::prelude::*;
 
 use crate::events::LambdaEventBuilder;
 use http::{Method, Response};
@@ -11,6 +13,10 @@ use httpmock::{
 use hyper::{body, Body};
 use lambda_web_adapter::{Adapter, AdapterOptions, Protocol};
 use tower::Service;
+
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 
 #[test]
 fn test_adapter_options_from_env() {
@@ -53,6 +59,7 @@ async fn test_http_readiness_check() {
         readiness_check_protocol: Protocol::Http,
         async_init: false,
         base_path: None,
+        compression: false,
     };
 
     // Initialize adapter and do readiness check
@@ -81,6 +88,7 @@ async fn test_http_basic_request() {
         readiness_check_protocol: Protocol::Http,
         async_init: false,
         base_path: None,
+        compression: false,
     });
 
     // // Call the adapter service with basic request
@@ -92,6 +100,7 @@ async fn test_http_basic_request() {
 
     // and response has expected content
     assert_eq!(200, response.status());
+    assert_eq!(response.headers().get("content-length").unwrap(), "11");
     assert_eq!("Hello World", body_to_string(response).await);
 }
 
@@ -115,6 +124,7 @@ async fn test_http_headers() {
         readiness_check_protocol: Protocol::Http,
         async_init: false,
         base_path: None,
+        compression: false,
     });
 
     // Prepare request
@@ -159,6 +169,7 @@ async fn test_http_query_params() {
         readiness_check_protocol: Protocol::Http,
         async_init: false,
         base_path: None,
+        compression: false,
     });
 
     // Prepare request
@@ -207,6 +218,7 @@ async fn test_http_post_put_delete() {
         readiness_check_protocol: Protocol::Http,
         async_init: false,
         base_path: None,
+        compression: false,
     });
 
     // Prepare requests
@@ -243,7 +255,144 @@ async fn test_http_post_put_delete() {
     assert_eq!("DELETE Success", body_to_string(delete_response).await);
 }
 
+#[tokio::test]
+async fn test_http_compress() {
+    // Start app server
+    let app_server = MockServer::start();
+    let hello = app_server.mock(|when, then| {
+        when.method(GET).path("/hello");
+        then.status(200)
+            .header("content-type", "text/plain")
+            .body("Hello World Hello World Hello World Hello World Hello World");
+    });
+
+    // Initialize adapter
+    let mut adapter = Adapter::new(&AdapterOptions {
+        host: app_server.host(),
+        port: app_server.port().to_string(),
+        readiness_check_port: app_server.port().to_string(),
+        readiness_check_path: "/healthcheck".to_string(),
+        readiness_check_protocol: Protocol::Http,
+        async_init: false,
+        base_path: None,
+        compression: true,
+    });
+
+    // // Call the adapter service with basic request
+    let req = LambdaEventBuilder::new()
+        .with_path("/hello").with_header("accept-encoding", "gzip").build();
+    let response = adapter.call(req.into()).await.expect("Request failed");
+
+    // Assert endpoint was called once
+    hello.assert();
+
+    // and response has expected content
+    assert_eq!(200, response.status());
+    assert_eq!(response.headers().get("content-length").unwrap(), "48"); // uncompressed: 59
+    assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+    assert_eq!("Hello World Hello World Hello World Hello World Hello World",
+        compressed_body_to_string(response).await);
+}
+
+#[tokio::test]
+async fn test_http_compress_disallowed_type() {
+    // Start app server
+    let app_server = MockServer::start();
+    let hello = app_server.mock(|when, then| {
+        when.method(GET).path("/hello");
+        then.status(200)
+            .header("content-type", "application/octet-stream")
+            .body("Hello World Hello World Hello World Hello World Hello World");
+    });
+
+    // Initialize adapter
+    let mut adapter = Adapter::new(&AdapterOptions {
+        host: app_server.host(),
+        port: app_server.port().to_string(),
+        readiness_check_port: app_server.port().to_string(),
+        readiness_check_path: "/healthcheck".to_string(),
+        readiness_check_protocol: Protocol::Http,
+        async_init: false,
+        base_path: None,
+        compression: true,
+    });
+
+    // // Call the adapter service with basic request
+    let req = LambdaEventBuilder::new()
+        .with_path("/hello").with_header("accept-encoding", "gzip").build();
+    let response = adapter.call(req.into()).await.expect("Request failed");
+
+    // Assert endpoint was called once
+    hello.assert();
+
+    // and response has expected content
+    assert_eq!(200, response.status());
+    assert_eq!(response.headers().get("content-length").unwrap(), "59"); // uncompressed: 59
+    assert_eq!(response.headers().contains_key("content-encoding"), false);
+    assert_eq!("Hello World Hello World Hello World Hello World Hello World", body_to_string(response).await);
+}
+
+#[tokio::test]
+async fn test_http_compress_already_compressed() {
+    unsafe {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(b"Hello World Hello World Hello World Hello World Hello World").unwrap();
+        let gzipped_body = encoder.finish();
+
+        // Turn the vector into a fake string
+        let gzipped_body = String::from_utf8_unchecked(gzipped_body.unwrap());
+
+        // Start app server
+        let app_server = MockServer::start();
+        let hello = app_server.mock(|when, then| {
+            when.method(GET).path("/hello");
+            then.status(200)
+                .header("content-encoding", "gzip")
+                .body(gzipped_body);
+        });
+
+        // Initialize adapter
+        let mut adapter = Adapter::new(&AdapterOptions {
+            host: app_server.host(),
+            port: app_server.port().to_string(),
+            readiness_check_port: app_server.port().to_string(),
+            readiness_check_path: "/healthcheck".to_string(),
+            readiness_check_protocol: Protocol::Http,
+            async_init: false,
+            base_path: None,
+            compression: true,
+        });
+
+        // Call the adapter service with basic request
+        let req = LambdaEventBuilder::new()
+            .with_path("/hello").with_header("accept-encoding", "gzip").build();
+        let response = adapter.call(req.into()).await.expect("Request failed");
+
+        // Assert endpoint was called once
+        hello.assert();
+
+        // and response has expected content
+        assert_eq!(200, response.status());
+        assert_eq!(response.headers().get("content-length").unwrap(), "48"); // uncompressed: 59
+        assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+        assert_eq!("Hello World Hello World Hello World Hello World Hello World",
+            compressed_body_to_string(response).await);
+    }
+}
+
 async fn body_to_string(res: Response<Body>) -> String {
     let body_bytes = body::to_bytes(res.into_body()).await.unwrap();
     String::from_utf8(body_bytes.to_vec()).unwrap()
 }
+
+async fn compressed_body_to_string(res: Response<Body>) -> String {
+    let body_bytes = body::to_bytes(res.into_body()).await.unwrap();
+    decode_reader(&body_bytes.to_vec()).unwrap()
+}
+
+fn decode_reader(bytes: &Vec<u8>) -> io::Result<String> {
+    let mut gz = GzDecoder::new(&bytes[..]);
+    let mut s = String::new();
+    gz.read_to_string(&mut s)?;
+    Ok(s)
+ }

--- a/tests/integ_tests.rs
+++ b/tests/integ_tests.rs
@@ -347,15 +347,13 @@ async fn test_http_compress_already_compressed() {
     encoder
         .write_all(b"Hello World Hello World Hello World Hello World Hello World")
         .unwrap();
-    let gzipped_body = encoder.finish();
+    let gzipped_body = encoder.finish().unwrap();
 
     // Start app server
     let app_server = MockServer::start();
     let hello = app_server.mock(|when, then| {
         when.method(GET).path("/hello");
-        then.status(200)
-            .header("content-encoding", "gzip")
-            .body(&gzipped_body.unwrap());
+        then.status(200).header("content-encoding", "gzip").body(&gzipped_body);
     });
 
     // Initialize adapter


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- Compress responses when the `COMPRESSION` env var is `true`, when the response is not already compressed, and when the `content-type` starts with `text/` or is one of a few known types such as `application/javascript`
- The list of mime types to compress is not configurable to align with the way CloudFront handles automatic compression if enabled - the list of mime types that should / should not be compressed is something that is largely configurable one time and does not need to be adjusted or excruciatingly specified by each consumer (like nginx requires)
- Set the `Content-Length` response header to have the correct compressed length
- Set the `Content-Encoding` response header to `gzip` if compression is performed

### Motivations
- This project is awesome and I'm going to incorporate it into the documentation and examples for my [MicroApps](https://github.com/pwrdrvr/microapps-core) framework as the suggested method for quickly converting web apps to run as Lambda functions
- Node.js is exceedingly slow at performing gzip compression, particularly of large response bodies
- Lambda functions exposed via CloudFront connected to Function URLs with SigV4 signing do not have another place where compression of the response can be guaranteed, particularly on non-cacheable responses (which CloudFront either never or sometimes does not compress)
- Rust compressing the response should be substantially faster (I didn't even measure it as I've done extensive measurements of Node.js gzip performance for other projects... it's bad)
- This is a feature I need to allow Lambda to tie or beat the current deployment pattern for an existing site 

### To-Do / Seeking Input
- [x] Should the `COMPRESSION` env var name be the first name-spaced env var such as `LAMBDA_ADAPTER_COMPRESSION`?
- [x] Do we have deployed integration tests that will confirm this works in the wild?  I wasn't sure where to put those
- [x] I assume the lambda http crate is handling marking the response as base64 encoded and handling the base64 encoding when it sees the gzip content-encoding - could someone confirm that?  I see that nginx is sending gzip responses through the adapter so I assume this is all working correctly already
- [x] The use of `unsafe` in one of the tests (not deployed code) was gross, but there does not appear to be a body function that takes a byte array so I had to fake it as a non-validated string - Any suggestions for that test would be welcome

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
