### PR TITLE
Separate HTTPS and HTTP adapters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,15 +15,28 @@ async fn main() -> Result<(), Error> {
     // get configuration options from environment variables
     let options = AdapterOptions::from_env();
 
-    // create an adapter
-    let mut adapter = Adapter::new(&options);
+    match options.enable_tls {
+        false => {
+            // create a HTTP adapter
+            let mut adapter = Adapter::new(&options);
+            // register the adapter as an extension
+            adapter.register_default_extension();
+            // check if the web application is ready
+            adapter.check_init_health().await;
+            // start lambda runtime after the web application is ready
+            adapter.run().await.expect("lambda runtime failed");
+        }
+        true => {
+            // create a HTTPS adapter
+            let mut adapter = Adapter::new_https(&options);
+            // register the adapter as an extension
+            adapter.register_default_extension();
+            // check if the web application is ready
+            adapter.check_init_health().await;
+            // start lambda runtime after the web application is ready
+            adapter.run().await.expect("lambda runtime failed");
+        }
+    }
 
-    // register the adapter as an extension
-    adapter.register_default_extension();
-
-    // check if the web application is ready
-    adapter.check_init_health().await;
-
-    // start lambda runtime after the web application is ready
-    adapter.run().await
+    Ok(())
 }


### PR DESCRIPTION
This prevents issues when ca certs are not available in custom docker images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
