### PR TITLE
Add streaming response support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,9 +236,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-sigv4"
-version = "0.54.1"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdaf11005b7444e6cd66f600d09861a3aeb6eb89a0f003c7c9820dbab2d15297"
+checksum = "86529e7b64d902efea8fff52c1b2529368d04f90305cf632729e3713f6b57dc0"
 dependencies = [
  "aws-smithy-http",
  "form_urlencoded",
@@ -376,9 +389,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -852,6 +865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "http-serde"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -903,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -926,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
@@ -1062,14 +1081,15 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16fd842ce9fc6908f1688030cf8b6841e2009bd874eb21244f124570ac06264f"
+checksum = "b2f580d0cf5364705314779cded5f8a4a9c856b104361ce18254e05969793933"
 dependencies = [
  "aws_lambda_events",
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
+ "futures",
  "http",
  "http-body 0.4.5",
  "hyper",
@@ -1084,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b0f7b71dc8707ecf8e230aa1ef8ffad0a718742f9195fda4edae1ccf48af1c"
+checksum = "124a7d502e26b1ae9645bafd964d299d9c0d882cc8b3e228604d02bf0e13fc87"
 dependencies = [
  "async-stream",
  "bytes",
@@ -1104,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7210012be904051520f0dc502140ba599bae3042b65b3737b87727f1aa88a7d6"
+checksum = "690c5ae01f3acac8c9c3348b556fc443054e9b7f1deaf53e9ebab716282bf0ed"
 dependencies = [
  "http",
  "hyper",
@@ -1130,6 +1150,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1149,9 +1170,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1549,14 +1570,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -1578,6 +1599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1770,9 +1801,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -1947,13 +1978,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1963,6 +1993,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -1983,6 +2026,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.5",
+ "http-range-header",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,9 +2060,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -2009,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2020,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -2232,16 +2296,6 @@ checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ exclude = ["examples"]
 [dependencies]
 http = "0.2"
 hyper = { version = "0.14", features = ["client"] }
-hyper-rustls = "0.23.2"
-lambda_http = "0.7.3"
+hyper-rustls = "0.24"
+lambda_http = "0.8"
 flate2 = "1.0.25"
 tokio = { version = "1.24", features = [
     "macros",
@@ -35,8 +35,9 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }
-tower = "0.4.13"
-url = "2.3.1"
+tower = "0.4"
+tower-http = { version = "0.4", features = ["compression-gzip"] }
+url = "2.3"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -408,7 +408,7 @@ async fn test_http_compress_disallowed_type() {
     let response = adapter.call(req.into()).await.expect("Request failed");
 
     // Assert endpoint was called once
-    hello.assert(); 
+    hello.assert();
 
     // and response has expected content
     assert_eq!(200, response.status());

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -11,12 +11,13 @@ use httpmock::{
     MockServer,
 };
 use hyper::{body, Body};
-use lambda_web_adapter::{Adapter, AdapterOptions, Protocol};
-use tower::Service;
+use lambda_web_adapter::{Adapter, AdapterOptions, LambdaInvokeMode, Protocol};
+use tower::{Service, ServiceBuilder};
 
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use tower_http::compression::{CompressionBody, CompressionLayer};
 
 #[test]
 fn test_adapter_options_from_env() {
@@ -71,6 +72,7 @@ async fn test_http_readiness_check() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     };
 
     // Initialize adapter and do readiness check
@@ -103,6 +105,7 @@ async fn test_http_basic_request() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
 
     // // Call the adapter service with basic request
@@ -142,6 +145,7 @@ async fn test_http_headers() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
 
     // Prepare request
@@ -187,6 +191,7 @@ async fn test_http_path_encoding() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
 
     // Prepare request
@@ -230,6 +235,7 @@ async fn test_http_query_params() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
 
     // Prepare request
@@ -282,6 +288,7 @@ async fn test_http_post_put_delete() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
 
     // Prepare requests
@@ -330,7 +337,7 @@ async fn test_http_compress() {
     });
 
     // Initialize adapter
-    let mut adapter = Adapter::new(&AdapterOptions {
+    let adapter = Adapter::new(&AdapterOptions {
         host: app_server.host(),
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
@@ -342,21 +349,23 @@ async fn test_http_compress() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
+
+    let mut svc = ServiceBuilder::new().layer(CompressionLayer::new()).service(adapter);
 
     // // Call the adapter service with basic request
     let req = LambdaEventBuilder::new()
         .with_path("/hello")
         .with_header("accept-encoding", "gzip")
         .build();
-    let response = adapter.call(req.into()).await.expect("Request failed");
+    let response = svc.call(req.into()).await.expect("Request failed");
 
     // Assert endpoint was called once
     hello.assert();
 
     // and response has expected content
     assert_eq!(200, response.status());
-    assert_eq!(response.headers().get("content-length").unwrap(), "48"); // uncompressed: 59
     assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
     assert_eq!(
         "Hello World Hello World Hello World Hello World Hello World",
@@ -388,6 +397,7 @@ async fn test_http_compress_disallowed_type() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
 
     // // Call the adapter service with basic request
@@ -398,7 +408,7 @@ async fn test_http_compress_disallowed_type() {
     let response = adapter.call(req.into()).await.expect("Request failed");
 
     // Assert endpoint was called once
-    hello.assert();
+    hello.assert(); 
 
     // and response has expected content
     assert_eq!(200, response.status());
@@ -426,7 +436,7 @@ async fn test_http_compress_already_compressed() {
     });
 
     // Initialize adapter
-    let mut adapter = Adapter::new(&AdapterOptions {
+    let adapter = Adapter::new(&AdapterOptions {
         host: app_server.host(),
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
@@ -438,14 +448,17 @@ async fn test_http_compress_already_compressed() {
         enable_tls: false,
         tls_server_name: None,
         tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
     });
+
+    let mut svc = ServiceBuilder::new().layer(CompressionLayer::new()).service(adapter);
 
     // Call the adapter service with basic request
     let req = LambdaEventBuilder::new()
         .with_path("/hello")
         .with_header("accept-encoding", "gzip")
         .build();
-    let response = adapter.call(req.into()).await.expect("Request failed");
+    let response = svc.call(req.into()).await.expect("Request failed");
 
     // Assert endpoint was called once
     hello.assert();
@@ -465,7 +478,7 @@ async fn body_to_string(res: Response<Body>) -> String {
     String::from_utf8_lossy(&body_bytes).to_string()
 }
 
-async fn compressed_body_to_string(res: Response<Body>) -> String {
+async fn compressed_body_to_string(res: Response<CompressionBody<Body>>) -> String {
     let body_bytes = body::to_bytes(res.into_body()).await.unwrap();
     decode_reader(&body_bytes).unwrap()
 }


### PR DESCRIPTION
This PR adds support for Lambda Streaming Response. I switched the response compression to `tow_http::compression::CompressionLayer`, because it supports the streaming body.

*Issue #, if available:*

close #203 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
