### PR TITLE
Tighten HTTP readiness check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,9 +286,9 @@ where
     async fn check_web_readiness(&self, url: &Url, protocol: &Protocol) -> Result<(), i8> {
         match protocol {
             Protocol::Http => match self.client.get(url.to_string().parse().unwrap()).await {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    tracing::debug!(err =?e, "app is not ready");
+                Ok(response) if { 500 > response.status().as_u16() && response.status().as_u16() >= 100 } => Ok(()),
+                _ => {
+                    tracing::debug!("app is not ready");
                     Err(-1)
                 }
             },


### PR DESCRIPTION
*Issue #, if available:*

close #141 

*Description of changes:*

Tighten HTTP readiness check: 

500 > status >= 100 => ready
otherwise => not ready

This will avoid issues when nginx proxing a web app and the web app is slow to start.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
