### PR TITLE
Fix FastAPI description in the sam template.

### DIFF
--- a/examples/fastapi/template.yaml
+++ b/examples/fastapi/template.yaml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   python3.8
 
-  Sample SAM Template for flask
+  Sample SAM Template for FastAPI
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
I found an oversight in the FastAPI example, which appears to be a remnant from a copied Flask example. This PR updates the description of the CloudFormation Stack in the sam template to accurately reflect the example of FastAPI implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
