### PR TITLE
Add AWS_LWA_PORT as a fallback for readiness_check_port.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,8 @@ impl AdapterOptions {
             readiness_check_port: env::var("AWS_LWA_READINESS_CHECK_PORT").unwrap_or(
                 env::var("READINESS_CHECK_PORT").unwrap_or(
                     env::var("AWS_LWA_PORT")
-                        .unwrap_or_else(|_| env::var("PORT").unwrap_or_else(|_| "8080".to_string()))),
+                        .unwrap_or_else(|_| env::var("PORT").unwrap_or_else(|_| "8080".to_string())),
+                ),
             ),
             readiness_check_path: env::var("AWS_LWA_READINESS_CHECK_PATH")
                 .unwrap_or(env::var("READINESS_CHECK_PATH").unwrap_or_else(|_| "/".to_string())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,9 @@ impl AdapterOptions {
             host: env::var("AWS_LWA_HOST").unwrap_or(env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string())),
             port: env::var("AWS_LWA_PORT").unwrap_or(env::var("PORT").unwrap_or_else(|_| "8080".to_string())),
             readiness_check_port: env::var("AWS_LWA_READINESS_CHECK_PORT").unwrap_or(
-                env::var("READINESS_CHECK_PORT")
-                    .unwrap_or_else(|_| env::var("PORT").unwrap_or_else(|_| "8080".to_string())),
+                env::var("READINESS_CHECK_PORT").unwrap_or(
+                    env::var("AWS_LWA_PORT")
+                        .unwrap_or_else(|_| env::var("PORT").unwrap_or_else(|_| "8080".to_string()))),
             ),
             readiness_check_path: env::var("AWS_LWA_READINESS_CHECK_PATH")
                 .unwrap_or(env::var("READINESS_CHECK_PATH").unwrap_or_else(|_| "/".to_string())),

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -85,6 +85,17 @@ fn test_adapter_options_from_namespaced_env() {
     assert_eq!(LambdaInvokeMode::ResponseStream, options.invoke_mode);
 }
 
+#[test]
+fn test_readiness_check_port_fallback_to_lwa_port() {
+    env::set_var("AWS_LWA_PORT", "3000");
+
+    // Initialize adapter with env options
+    let options = AdapterOptions::from_env();
+    Adapter::new(&options);
+
+    assert_eq!("3000", options.readiness_check_port);
+}
+
 #[tokio::test]
 async fn test_http_readiness_check() {
     // Start app server


### PR DESCRIPTION
*Issue #, if available:* #245

*Description of changes:* Add `AWS_LWA_PORT` as a fallback for `readiness_check_port`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
