### PR TITLE
Pass Lambda Context to web app in a new header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,7 @@ where
         }
 
         let request_context = event.request_context();
+        let lambda_context = &event.lambda_context();
         let path = event.raw_http_path().to_string();
         let mut path = path.as_str();
         let (parts, body) = event.into_parts();
@@ -349,6 +350,11 @@ where
             HeaderValue::from_bytes(serde_json::to_string(&request_context)?.as_bytes())?,
         );
 
+        // include lambda context in http header "x-amzn-lambda-context"
+        req_headers.append(
+            HeaderName::from_static("x-amzn-lambda-context"),
+            HeaderValue::from_bytes(serde_json::to_string(&lambda_context)?.as_bytes())?,
+        );
         let mut app_url = self.domain.clone();
         app_url.set_path(path);
         app_url.set_query(parts.uri.query());

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -572,6 +572,54 @@ async fn test_http_compress_already_compressed() {
     );
 }
 
+#[tokio::test]
+async fn test_http_lambda_context_header() {
+    // Start app server
+    let app_server = MockServer::start();
+
+    // An endpoint that expects and returns headers
+    let test_endpoint = app_server.mock(|when, then| {
+        when.method(GET).path("/").header_exists("x-amzn-lambda-context");
+        then.status(200).header("fizz", "buzz").body("OK");
+    });
+
+    // Initialize adapter and do readiness check
+    let mut adapter = Adapter::new(&AdapterOptions {
+        host: app_server.host(),
+        port: app_server.port().to_string(),
+        readiness_check_port: app_server.port().to_string(),
+        readiness_check_path: "/healthcheck".to_string(),
+        readiness_check_protocol: Protocol::Http,
+        async_init: false,
+        base_path: None,
+        compression: false,
+        enable_tls: false,
+        tls_server_name: None,
+        tls_cert_file: None,
+        invoke_mode: LambdaInvokeMode::Buffered,
+    });
+
+    // Prepare request
+    let req = LambdaEventBuilder::new().with_path("/").build();
+
+    // We convert to Request object because it allows us to add
+    // the Lambda Context
+    let mut request = Request::from(req);
+    add_lambda_context_to_request(&mut request);
+
+    // Call the adapter service with request
+    let response = adapter.call(request).await.expect("Request failed");
+
+    // Assert endpoint was called once
+    test_endpoint.assert();
+
+    // and response has expected content
+    assert_eq!(200, response.status());
+    assert!(response.headers().contains_key("fizz"));
+    assert_eq!("buzz", response.headers().get("fizz").unwrap());
+    assert_eq!("OK", body_to_string(response).await);
+}
+
 async fn body_to_string(res: Response<Body>) -> String {
     let body_bytes = body::to_bytes(res.into_body()).await.unwrap();
     String::from_utf8_lossy(&body_bytes).to_string()


### PR DESCRIPTION
*Issue #, if available:* #244

*Description of changes:*

Made Lambda Context available to web apps in a new header (x-amzn-lambda-context).

**Note :** The implementation broke some tests because the `LambdaRequest` object used to send the request to the mock server doesn't have a lambda context, resulting in an error ("Request did not contain a lambda context") when `"let lambda_context = &event.lambda_context();"` is called. I fixed this by replacing `LambdaRequest` with `Request`, which allows adding the lambda context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
