### PR TITLE
Add option to override unhealthy status so 4xx can be unhealthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The readiness check port/path and traffic port can be configured using environme
 | AWS_LWA_READINESS_CHECK_PORT / READINESS_CHECK_PORT*         | readiness check port, default to the traffic port                                    | PORT        |
 | AWS_LWA_READINESS_CHECK_PATH / READINESS_CHECK_PATH*         | readiness check path                                                                 | "/"         |
 | AWS_LWA_READINESS_CHECK_PROTOCOL / READINESS_CHECK_PROTOCOL* | readiness check protocol: "http" or "tcp", default is "http"                         | "http"      |
+| AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS                 | The minimum HTTP status code that is considered unhealthy                            | "500"  |
 | AWS_LWA_ASYNC_INIT / ASYNC_INIT*                             | enable asynchronous initialization for long initialization functions                 | "false"     |
 | AWS_LWA_REMOVE_BASE_PATH / REMOVE_BASE_PATH*                 | the base path to be removed from request path                                        | None        |
 | AWS_LWA_ENABLE_COMPRESSION                                   | enable gzip compression for response body                                            | "false"     |
@@ -125,6 +126,8 @@ Please check out [FastAPI with HTTPS](examples/fastapi-https) example for more d
 
 **AWS_LWA_INVOKE_MODE** - Lambda function invoke mode, this should match Function Url invoke mode. The default is "buffered". When configured as "response_stream", Lambda Web Adapter will stream response to Lambda service [blog](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/). 
 Please check out [FastAPI with Response Streaming](examples/fastapi-response-streaming) example. 
+
+**AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS** - allows you to customize which HTTP status codes are considered healthy and which ones are not
 
 ## Request Context
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,14 @@ where
     async fn check_web_readiness(&self, url: &Url, protocol: &Protocol) -> Result<(), i8> {
         match protocol {
             Protocol::Http => match self.client.get(url.to_string().parse().unwrap()).await {
-                Ok(response) if { self.healthcheck_min_unhealthy_status > response.status().as_u16() && response.status().as_u16() >= 100 } => Ok(()),
+                Ok(response)
+                    if {
+                        self.healthcheck_min_unhealthy_status > response.status().as_u16()
+                            && response.status().as_u16() >= 100
+                    } =>
+                {
+                    Ok(())
+                }
                 _ => {
                     tracing::debug!("app is not ready");
                     Err(-1)
@@ -404,16 +411,10 @@ where
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use httpmock::{
-        Method::{GET},
-        MockServer,
-    };
-    
+    use httpmock::{Method::GET, MockServer};
 
     #[tokio::test]
     async fn test_status_200_is_ok() {

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -59,6 +59,7 @@ fn test_adapter_options_from_env() {
 fn test_adapter_options_from_namespaced_env() {
     env::set_var("AWS_LWA_PORT", "3000");
     env::set_var("AWS_LWA_HOST", "localhost");
+    env::set_var("AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS", "400");
     env::set_var("AWS_LWA_READINESS_CHECK_PORT", "8000");
     env::set_var("AWS_LWA_READINESS_CHECK_PROTOCOL", "TCP");
     env::set_var("AWS_LWA_READINESS_CHECK_PATH", "/healthcheck");
@@ -75,6 +76,7 @@ fn test_adapter_options_from_namespaced_env() {
     Adapter::new(&options);
 
     assert_eq!("3000", options.port);
+    assert_eq!(400, options.readiness_check_min_unhealthy_status);
     assert_eq!("localhost", options.host);
     assert_eq!("8000", options.readiness_check_port);
     assert_eq!("/healthcheck", options.readiness_check_path);
@@ -117,6 +119,7 @@ async fn test_http_readiness_check() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,
@@ -150,6 +153,7 @@ async fn test_http_basic_request() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,
@@ -196,6 +200,7 @@ async fn test_http_headers() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,
@@ -247,6 +252,7 @@ async fn test_http_path_encoding() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,
@@ -296,6 +302,7 @@ async fn test_http_query_params() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,
@@ -354,6 +361,7 @@ async fn test_http_post_put_delete() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,
@@ -424,6 +432,7 @@ async fn test_http_compress() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: true,
@@ -478,6 +487,7 @@ async fn test_http_compress_disallowed_type() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: true,
@@ -535,6 +545,7 @@ async fn test_http_compress_already_compressed() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: true,
@@ -590,6 +601,7 @@ async fn test_http_lambda_context_header() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         readiness_check_protocol: Protocol::Http,
+        readiness_check_min_unhealthy_status: 500,
         async_init: false,
         base_path: None,
         compression: false,


### PR DESCRIPTION
*Issue #251*

*Description of changes:*
I added an optional environment variable called AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS that will let me override the lowest status code that is considered unhealthy.  This is currently hardcoded to 500.  This PR allows me to override it.  The default remains at 500 as to not impact existing users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.