### PR TITLE
fix: set arm64_supported to false on eu-central-2

### DIFF
--- a/.github/workflows/gamma.json
+++ b/.github/workflows/gamma.json
@@ -108,7 +108,7 @@
     "cloudformation_execution_role": "arn:aws:iam::520465526641:role/aws-sam-cli-managed-gamma-CloudFormationExecutionR-QL5NJ1OADKBF",
     "image_repository": "520465526641.dkr.ecr.eu-central-2.amazonaws.com/aws-sam-cli-managed-gamma-pipeline-resources-imagerepository-ze9skredlbdh",
     "pipeline_execution_role": "arn:aws:iam::520465526641:role/aws-sam-cli-managed-gamma-pi-PipelineExecutionRole-8L89W4PHSJEB",
-    "arm64_supported": true,
+    "arm64_supported": false,
     "region": "eu-central-2"
   },
   {

--- a/.github/workflows/prod.json
+++ b/.github/workflows/prod.json
@@ -108,7 +108,7 @@
     "cloudformation_execution_role": "arn:aws:iam::753240598075:role/aws-sam-cli-managed-prod-CloudFormationExecutionR-17XUGNR78X1IV",
     "image_repository": "753240598075.dkr.ecr.eu-central-2.amazonaws.com/aws-sam-cli-managed-prod-pipeline-resources-imagerepository-hq5etbb2coxu",
     "pipeline_execution_role": "arn:aws:iam::753240598075:role/aws-sam-cli-managed-prod-pip-PipelineExecutionRole-1U6SYAYUQW3LH",
-    "arm64_supported": true,
+    "arm64_supported": false,
     "region": "eu-central-2"
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deploy only the x86_64 version of the LWA layer in eu-central-2 as arm64 version is not supported yet.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
