### PR TITLE
fix: override user-set `x-amzn-{lambda,request}-context` headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,13 +360,13 @@ where
         let mut req_headers = parts.headers;
 
         // include request context in http header "x-amzn-request-context"
-        req_headers.append(
+        req_headers.insert(
             HeaderName::from_static("x-amzn-request-context"),
             HeaderValue::from_bytes(serde_json::to_string(&request_context)?.as_bytes())?,
         );
 
         // include lambda context in http header "x-amzn-lambda-context"
-        req_headers.append(
+        req_headers.insert(
             HeaderName::from_static("x-amzn-lambda-context"),
             HeaderValue::from_bytes(serde_json::to_string(&lambda_context)?.as_bytes())?,
         );


### PR DESCRIPTION
*Description of changes:*

Currently, when a client sets their own `x-amzn-{lambda,request}-context` headers, they will be included in the request to the app server.

This request to the lambda with the adapter installed:

```
$ curl -H "x-amzn-request-context: boom" http://localhost:8000
```

Will result in this request from the adapter to the app server:

```
GET / HTTP/1.1
[...]
x-amzn-request-context: boom
x-amzn-request-context: [json context from adapter]
x-amzn-lambda-context: [json context from adapter]
[...]
```

Many implementations of web frameworks will take the *first* header when you access a header key.

For example, Starlette/FastAPI does this:
https://github.com/encode/starlette/blob/ad02ee6336faadadf97e0c79dd3a91759f1f32a7/starlette/datastructures.py#L562-L567

This patch overrides every user-set `x-amzn-{request,lambda}-context` headers from the request by JSON context headers from the adapter.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
