### PR TITLE
Upgraded lambda-http crate to v0.8.3 to fix Content-Type processing issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "lambda_web_adapter"
-version = "0.7.2"
+version = "0.7.1"
 dependencies = [
  "aws-sigv4",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -191,7 +200,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -208,7 +217,7 @@ checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -289,27 +298,40 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "0.7.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e4623e6898c4590b27eb26d64f498513b9e4c7b52537f64f75d3f423483c51"
+checksum = "2c2981b7ab5d084f06dfa6764e2b51347e836fe9559b549b332e451e6a8287ae"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytes",
- "chrono",
  "http",
  "http-body 0.4.5",
  "http-serde",
  "query_map",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
 [[package]]
-name = "base64"
-version = "0.13.0"
+name = "backtrace"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.7.1",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -426,17 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,7 +522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -635,7 +646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -646,9 +657,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -724,7 +735,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -779,6 +790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -873,9 +890,9 @@ checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "http-serde"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d98b3d9662de70952b14c4840ee0f37e23973542a363e2275f4b9d024ff6cca"
+checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
 dependencies = [
  "http",
  "serde",
@@ -895,14 +912,14 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpmock"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c159c4fc205e6c1a9b325cb7ec135d13b5f47188ce175dabb76ec847f331d9bd"
+checksum = "4b02e044d3b4c2f94936fb05f9649efa658ca788f44eb6b87554e2033fc8ce93"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.21.0",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -962,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1065,7 +1082,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.27",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1083,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f580d0cf5364705314779cded5f8a4a9c856b104361ce18254e05969793933"
+checksum = "2505c4a24f5a8d8ac66a87691215ec1f79736c5bc6e62bb921788dca9753f650"
 dependencies = [
  "aws_lambda_events",
  "base64 0.21.0",
@@ -1101,23 +1118,28 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "tokio-stream",
  "url",
 ]
 
 [[package]]
 name = "lambda_runtime"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124a7d502e26b1ae9645bafd964d299d9c0d882cc8b3e228604d02bf0e13fc87"
+checksum = "deca8f65d7ce9a8bfddebb49d7d91b22e788a59ca0c5190f26794ab80ed7a702"
 dependencies = [
  "async-stream",
+ "base64 0.20.0",
  "bytes",
  "futures",
  "http",
+ "http-body 0.4.5",
+ "http-serde",
  "hyper",
  "lambda_runtime_api_client",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1138,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "lambda_web_adapter"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aws-sigv4",
  "flate2",
@@ -1149,6 +1171,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "lambda_http",
+ "serde_json",
  "tokio",
  "tokio-retry",
  "tower",
@@ -1172,9 +1195,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1224,14 +1247,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mime"
@@ -1249,15 +1272,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.4"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1293,6 +1324,15 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1357,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -1403,7 +1443,7 @@ checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1452,18 +1492,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "query_map"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4465aacac3bebc9484cf7a56dc8b2d7feacb657da6002a9198b4f7af4247a204"
+checksum = "5eab6b8b1074ef3359a863758dae650c7c0c6027927a085b7af911c8e0bf3a15"
 dependencies = [
  "form_urlencoded",
  "serde",
@@ -1472,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1531,13 +1571,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1546,7 +1587,18 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.27",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1554,6 +1606,12 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
@@ -1569,6 +1627,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustls"
@@ -1676,32 +1740,42 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -1848,6 +1922,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +1960,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1939,32 +2024,32 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2062,11 +2147,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2075,20 +2159,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -2105,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "once_cell",
@@ -2132,9 +2216,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -2144,9 +2228,9 @@ checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -2165,9 +2249,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2245,7 +2329,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -2279,7 +2363,7 @@ checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2350,13 +2434,37 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.0",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
  "windows_i686_msvc 0.42.0",
  "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2364,6 +2472,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2378,6 +2492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2508,12 @@ name = "windows_i686_gnu"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2402,6 +2528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,10 +2546,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2430,3 +2574,9 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ exclude = ["examples"]
 [dependencies]
 http = "0.2"
 hyper = { version = "0.14", features = ["client"] }
-lambda_http = "0.8"
-tokio = { version = "1.24", features = [
+lambda_http = "0.8.3"
+serde_json = "1.0"
+tokio = { version = "1.29", features = [
     "macros",
     "io-util",
     "sync",
@@ -28,8 +29,8 @@ tokio = { version = "1.24", features = [
     "time",
 ] }
 tokio-retry = "0.3"
-tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = [
+tracing = { version = "0.1.40", features = ["log"] }
+tracing-subscriber = { version = "0.3.17", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }
@@ -39,7 +40,7 @@ url = "2.3"
 
 [dev-dependencies]
 flate2 = "1.0.25"
-httpmock = "0.6"
+httpmock = "0.6.8"
 http-body-util = "0.1.0-rc.2"
 http-body = "0.4.5"
 hyper-rustls = "0.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@ impl From<&str> for LambdaInvokeMode {
     }
 }
 
-#[derive(Default)]
 pub struct AdapterOptions {
     pub host: String,
     pub port: String,
@@ -79,8 +78,8 @@ pub struct AdapterOptions {
     pub invoke_mode: LambdaInvokeMode,
 }
 
-impl AdapterOptions {
-    pub fn default() -> Self {
+impl Default for AdapterOptions {
+    fn default() -> Self {
         AdapterOptions {
             host: "127.0.0.1".to_string(),
             port: "8080".to_string(),
@@ -94,7 +93,9 @@ impl AdapterOptions {
             invoke_mode: LambdaInvokeMode::Buffered,
         }
     }
+}
 
+impl AdapterOptions {
     pub fn from_env() -> Self {
         AdapterOptions {
             host: env::var("AWS_LWA_HOST").unwrap_or(env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string())),
@@ -384,7 +385,7 @@ mod tests {
             port: app_server.port().to_string(),
             readiness_check_port: app_server.port().to_string(),
             readiness_check_path: "/healthcheck".to_string(),
-            ..AdapterOptions::default()
+            ..Default::default()
         };
 
         // Initialize adapter and do readiness check
@@ -416,7 +417,7 @@ mod tests {
             port: app_server.port().to_string(),
             readiness_check_port: app_server.port().to_string(),
             readiness_check_path: "/healthcheck".to_string(),
-            ..AdapterOptions::default()
+            ..Default::default()
         };
 
         // Initialize adapter and do readiness check
@@ -449,7 +450,7 @@ mod tests {
             readiness_check_port: app_server.port().to_string(),
             readiness_check_path: "/healthcheck".to_string(),
             readiness_check_min_unhealthy_status: 400,
-            ..AdapterOptions::default()
+            ..Default::default()
         };
 
         // Initialize adapter and do readiness check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use hyper::{
     client::{connect::Connect, Client, HttpConnector},
     Body,
 };
-use lambda_http::aws_lambda_events::serde_json;
 pub use lambda_http::Error;
 use lambda_http::{Request, RequestExt, Response};
 use tokio::net::TcpStream;
@@ -81,6 +80,21 @@ pub struct AdapterOptions {
 }
 
 impl AdapterOptions {
+    pub fn default() -> Self {
+        AdapterOptions {
+            host: "127.0.0.1".to_string(),
+            port: "8080".to_string(),
+            readiness_check_port: "8080".to_string(),
+            readiness_check_path: "/".to_string(),
+            readiness_check_protocol: Protocol::Http,
+            readiness_check_min_unhealthy_status: 500,
+            base_path: None,
+            async_init: false,
+            compression: false,
+            invoke_mode: LambdaInvokeMode::Buffered,
+        }
+    }
+
     pub fn from_env() -> Self {
         AdapterOptions {
             host: env::var("AWS_LWA_HOST").unwrap_or(env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string())),
@@ -370,12 +384,7 @@ mod tests {
             port: app_server.port().to_string(),
             readiness_check_port: app_server.port().to_string(),
             readiness_check_path: "/healthcheck".to_string(),
-            readiness_check_protocol: Protocol::Http,
-            readiness_check_min_unhealthy_status: 500,
-            async_init: false,
-            base_path: None,
-            compression: false,
-            invoke_mode: LambdaInvokeMode::Buffered,
+            ..AdapterOptions::default()
         };
 
         // Initialize adapter and do readiness check
@@ -407,12 +416,7 @@ mod tests {
             port: app_server.port().to_string(),
             readiness_check_port: app_server.port().to_string(),
             readiness_check_path: "/healthcheck".to_string(),
-            readiness_check_protocol: Protocol::Http,
-            readiness_check_min_unhealthy_status: 500,
-            async_init: false,
-            base_path: None,
-            compression: false,
-            invoke_mode: LambdaInvokeMode::Buffered,
+            ..AdapterOptions::default()
         };
 
         // Initialize adapter and do readiness check
@@ -444,12 +448,8 @@ mod tests {
             port: app_server.port().to_string(),
             readiness_check_port: app_server.port().to_string(),
             readiness_check_path: "/healthcheck".to_string(),
-            readiness_check_protocol: Protocol::Http,
             readiness_check_min_unhealthy_status: 400,
-            async_init: false,
-            base_path: None,
-            compression: false,
-            invoke_mode: LambdaInvokeMode::Buffered,
+            ..AdapterOptions::default()
         };
 
         // Initialize adapter and do readiness check

--- a/tests/e2e_tests/main.rs
+++ b/tests/e2e_tests/main.rs
@@ -4,8 +4,6 @@ use http::Uri;
 use hyper::client::HttpConnector;
 use hyper::{Body, Client, Method, Request};
 use hyper_rustls::HttpsConnector;
-use lambda_http::aws_lambda_events::serde_json;
-use lambda_http::aws_lambda_events::serde_json::Value;
 use std::env;
 use std::io;
 use std::io::prelude::*;
@@ -117,7 +115,7 @@ async fn test_http_headers() {
     let resp = client.request(req.map(Body::from)).await.unwrap();
     let (parts, body) = resp.into_parts();
     let body_bytes = hyper::body::to_bytes(body).await.unwrap();
-    let body = serde_json::from_slice::<Value>(&body_bytes).unwrap();
+    let body = serde_json::from_slice::<serde_json::Value>(&body_bytes).unwrap();
 
     assert_eq!(200, parts.status.as_u16());
     assert!(body["headers"]["Foo"][0].is_string());
@@ -141,7 +139,7 @@ async fn test_http_query_params() {
     let resp = client.request(req.map(Body::from)).await.unwrap();
     let (parts, body) = resp.into_parts();
     let body_bytes = hyper::body::to_bytes(body).await.unwrap();
-    let body = serde_json::from_slice::<Value>(&body_bytes).unwrap();
+    let body = serde_json::from_slice::<serde_json::Value>(&body_bytes).unwrap();
 
     assert_eq!(200, parts.status.as_u16());
     assert!(body["args"]["fizz"][0].is_string());

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -110,7 +110,7 @@ async fn test_http_readiness_check() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     };
 
     // Initialize adapter and do readiness check
@@ -136,7 +136,7 @@ async fn test_http_basic_request() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // // Call the adapter service with basic request
@@ -175,7 +175,7 @@ async fn test_http_headers() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare request
@@ -219,7 +219,7 @@ async fn test_http_path_encoding() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare request
@@ -261,7 +261,7 @@ async fn test_http_query_params() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare request
@@ -312,7 +312,7 @@ async fn test_http_post_put_delete() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare requests
@@ -376,7 +376,7 @@ async fn test_http_compress() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         compression: true,
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     let mut svc = ServiceBuilder::new().layer(CompressionLayer::new()).service(adapter);
@@ -424,7 +424,7 @@ async fn test_http_compress_disallowed_type() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         compression: true,
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // // Call the adapter service with basic request
@@ -475,7 +475,7 @@ async fn test_http_compress_already_compressed() {
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
         compression: true,
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     let mut svc = ServiceBuilder::new().layer(CompressionLayer::new()).service(adapter);
@@ -526,7 +526,7 @@ async fn test_http_context_headers() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare request
@@ -576,7 +576,7 @@ async fn test_http_content_encoding_suffix() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare request
@@ -639,7 +639,7 @@ async fn test_http_context_multi_headers() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        ..AdapterOptions::default()
+        ..Default::default()
     });
 
     // Prepare request

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -20,6 +20,7 @@ use tower::{Service, ServiceBuilder};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use serde_json::json;
 use tower_http::compression::{CompressionBody, CompressionLayer};
 
 #[test]
@@ -109,12 +110,7 @@ async fn test_http_readiness_check() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     };
 
     // Initialize adapter and do readiness check
@@ -140,12 +136,7 @@ async fn test_http_basic_request() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // // Call the adapter service with basic request
@@ -184,12 +175,7 @@ async fn test_http_headers() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // Prepare request
@@ -233,12 +219,7 @@ async fn test_http_path_encoding() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // Prepare request
@@ -280,12 +261,7 @@ async fn test_http_query_params() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // Prepare request
@@ -336,12 +312,7 @@ async fn test_http_post_put_delete() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // Prepare requests
@@ -404,12 +375,8 @@ async fn test_http_compress() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
         compression: true,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     let mut svc = ServiceBuilder::new().layer(CompressionLayer::new()).service(adapter);
@@ -456,12 +423,8 @@ async fn test_http_compress_disallowed_type() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
         compression: true,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // // Call the adapter service with basic request
@@ -511,12 +474,8 @@ async fn test_http_compress_already_compressed() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
         compression: true,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     let mut svc = ServiceBuilder::new().layer(CompressionLayer::new()).service(adapter);
@@ -567,12 +526,7 @@ async fn test_http_context_headers() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // Prepare request
@@ -594,6 +548,59 @@ async fn test_http_context_headers() {
     assert!(response.headers().contains_key("fizz"));
     assert_eq!("buzz", response.headers().get("fizz").unwrap());
     assert_eq!("OK", body_to_string(response).await);
+}
+
+#[tokio::test]
+async fn test_http_content_encoding_suffix() {
+    // Start app server
+    let app_server = MockServer::start();
+
+    let json_data = json!({
+        "name": "John Doe",
+        "age": 43,
+        "gender": "Male"
+    })
+    .to_string();
+
+    // An endpoint that expects and returns headers
+    let test_endpoint = app_server.mock(|when, then| {
+        when.method(GET).path("/json");
+        then.status(200)
+            .header("content-type", "application/graphql-response+json; charset=utf-8")
+            .body(json_data.to_owned());
+    });
+
+    // Initialize adapter and do readiness check
+    let mut adapter = Adapter::new(&AdapterOptions {
+        host: app_server.host(),
+        port: app_server.port().to_string(),
+        readiness_check_port: app_server.port().to_string(),
+        readiness_check_path: "/healthcheck".to_string(),
+        ..AdapterOptions::default()
+    });
+
+    // Prepare request
+    let req = LambdaEventBuilder::new().with_path("/json").build();
+
+    // We convert to Request object because it allows us to add
+    // the Lambda Context
+    let mut request = Request::from(req);
+    add_lambda_context_to_request(&mut request);
+
+    // Call the adapter service with request
+    let response = adapter.call(request).await.expect("Request failed");
+
+    // Assert endpoint was called once
+    test_endpoint.assert();
+
+    // and response has expected content
+    assert_eq!(200, response.status());
+    assert!(response.headers().contains_key("content-type"));
+    assert_eq!(
+        "application/graphql-response+json; charset=utf-8",
+        response.headers().get("content-type").unwrap()
+    );
+    assert_eq!(json_data.to_owned(), body_to_string(response).await);
 }
 
 #[tokio::test]
@@ -632,12 +639,7 @@ async fn test_http_context_multi_headers() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        readiness_check_protocol: Protocol::Http,
-        readiness_check_min_unhealthy_status: 500,
-        async_init: false,
-        base_path: None,
-        compression: false,
-        invoke_mode: LambdaInvokeMode::Buffered,
+        ..AdapterOptions::default()
     });
 
     // Prepare request


### PR DESCRIPTION
*Issue #, if available:*

Fix #265 

*Description of changes:*

lambda-http v0.8.3 contains the fix for Content-Type processing. Upgraded to this version to fix #265. Plus refactored a few tests. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
