### PR TITLE
add provided.al2023 to CompatibleRuntimes

### DIFF
--- a/template-arm64.yaml
+++ b/template-arm64.yaml
@@ -22,6 +22,7 @@ Resources:
         - dotnet6
         - dotnetcore3.1
         - provided.al2
+        - provided.al2023
       Description: 'Layer for AWS Lambda Adapter arm64'
       LicenseInfo: 'Available under the Apache-2.0 license.'
       RetentionPolicy: Retain

--- a/template-x86_64.yaml
+++ b/template-x86_64.yaml
@@ -24,6 +24,7 @@ Resources:
         - dotnetcore3.1
         - provided.al2
         - provided
+        - provided.al2023
       Description: 'Layer for AWS Lambda Adapter x86_64'
       LicenseInfo: 'Available under the Apache-2.0 license.'
       RetentionPolicy: Retain


### PR DESCRIPTION
*Issue #, if available:*
none

*Description of changes:*

add [provided.al2023](https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/) as compatible runtime for [x86_64 & arm64](https://github.com/amazonlinux/amazon-linux-2023?tab=readme-ov-file#architectures)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
