### PR TITLE
set AdapterOptions with env values in Default impl

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -80,3 +80,10 @@ When these commands complete successfully, you will have the following container
 - "aws-lambda-adapter:latest-x86_64" for x86_64.
 - "aws-lambda-adapter:latest-aarch64" for arm64.
 - "aws-lambda-adapter:latest" is the same as "aws-lambda-adapter:latest-x86_64".
+
+### Testing
+
+Please test with the following [commands](https://github.com/awslabs/aws-lambda-web-adapter/blob/ff2dc8bddd968e74d7dc2ec56a249c56e5a3c5a7/.github/workflows/pipeline.yaml#L46-L49) before submitting a pull request:
+1. `cargo fmt -- --check`
+1. `cargo clippy -- -Dwarnings`
+1. `cargo nextest run`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,23 +81,6 @@ pub struct AdapterOptions {
 impl Default for AdapterOptions {
     fn default() -> Self {
         AdapterOptions {
-            host: "127.0.0.1".to_string(),
-            port: "8080".to_string(),
-            readiness_check_port: "8080".to_string(),
-            readiness_check_path: "/".to_string(),
-            readiness_check_protocol: Protocol::Http,
-            readiness_check_min_unhealthy_status: 500,
-            base_path: None,
-            async_init: false,
-            compression: false,
-            invoke_mode: LambdaInvokeMode::Buffered,
-        }
-    }
-}
-
-impl AdapterOptions {
-    pub fn from_env() -> Self {
-        AdapterOptions {
             host: env::var("AWS_LWA_HOST").unwrap_or(env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string())),
             port: env::var("AWS_LWA_PORT").unwrap_or(env::var("PORT").unwrap_or_else(|_| "8080".to_string())),
             readiness_check_port: env::var("AWS_LWA_READINESS_CHECK_PORT").unwrap_or(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ where
         }
 
         let request_context = event.request_context();
-        let lambda_context = &event.lambda_context();
+        let lambda_context = event.lambda_context();
         let path = event.raw_http_path().to_string();
         let mut path = path.as_str();
         let (parts, body) = event.into_parts();

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt().with_env_filter(filter).without_time().init();
 
     // get configuration options from environment variables
-    let options = AdapterOptions::from_env();
+    let options = AdapterOptions::default();
 
     // create an adapter
     let mut adapter = Adapter::new(&options);

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -24,7 +24,7 @@ use serde_json::json;
 use tower_http::compression::{CompressionBody, CompressionLayer};
 
 #[test]
-fn test_adapter_options_from_env() {
+fn test_default_adapter_options() {
     env::set_var("PORT", "3000");
     env::set_var("HOST", "localhost");
     env::set_var("READINESS_CHECK_PORT", "8000");
@@ -38,8 +38,8 @@ fn test_adapter_options_from_env() {
     env::remove_var("AWS_LWA_TLS_CERT_FILE");
     env::set_var("AWS_LWA_INVOKE_MODE", "buffered");
 
-    // Initialize adapter with env options
-    let options = AdapterOptions::from_env();
+    // Initialize adapter
+    let options = AdapterOptions::default();
     Adapter::new(&options);
 
     assert_eq!("3000", options.port);
@@ -66,8 +66,8 @@ fn test_adapter_options_from_namespaced_env() {
     env::set_var("AWS_LWA_ENABLE_COMPRESSION", "true");
     env::set_var("AWS_LWA_INVOKE_MODE", "response_stream");
 
-    // Initialize adapter with env options
-    let options = AdapterOptions::from_env();
+    // Initialize adapter
+    let options = AdapterOptions::default();
     Adapter::new(&options);
 
     assert_eq!("3000", options.port);
@@ -88,8 +88,8 @@ fn test_readiness_check_port_fallback_to_lwa_port() {
     env::remove_var("READINESS_CHECK_PORT");
     env::set_var("AWS_LWA_PORT", "3000");
 
-    // Initialize adapter with env options
-    let options = AdapterOptions::from_env();
+    // Initialize adapter
+    let options = AdapterOptions::default();
     Adapter::new(&options);
 
     assert_eq!("3000", options.readiness_check_port);


### PR DESCRIPTION
*Issue #, if available:*

none

*Description of changes:*

* set AdapterOptions with env values in Default impl
* remove borrow for consistent lets
* ~add serial_test dev-dep~
* ~run 3 tests serially to avoid mixing env vars~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
