### PR TITLE
switch builder dockerfile to 2023 base image

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,7 +1,7 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as build-stage
 ARG ARCH=x86_64
-RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
-RUN yum groupinstall -y "Development tools"
+RUN dnf install -y jq
+RUN dnf groupinstall -y "Development tools"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
 RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \


### PR DESCRIPTION
*Issue #, if available:*

none

*Description of changes:*

switch builder dockerfile to 2023 base image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
