### PR TITLE
Remove 'CompatibleRuntimes' property on the Layers

### DIFF
--- a/template-arm64.yaml
+++ b/template-arm64.yaml
@@ -10,19 +10,6 @@ Resources:
       ContentUri: .
       CompatibleArchitectures:
         - arm64
-      CompatibleRuntimes:
-        - nodejs16.x
-        - nodejs14.x
-        - nodejs12.x
-        - python3.9
-        - python3.8
-        - ruby2.7
-        - java11
-        - java8.al2
-        - dotnet6
-        - dotnetcore3.1
-        - provided.al2
-        - provided.al2023
       Description: 'Layer for AWS Lambda Adapter arm64'
       LicenseInfo: 'Available under the Apache-2.0 license.'
       RetentionPolicy: Retain

--- a/template-x86_64.yaml
+++ b/template-x86_64.yaml
@@ -8,23 +8,6 @@ Resources:
     Type: AWS::Serverless::LayerVersion
     Properties:
       ContentUri: .
-      CompatibleRuntimes:
-        - nodejs16.x
-        - nodejs14.x
-        - nodejs12.x
-        - python3.9
-        - python3.8
-        - python3.7
-        - ruby2.7
-        - java11
-        - java8.al2
-        - java8
-        - go1.x
-        - dotnet6
-        - dotnetcore3.1
-        - provided.al2
-        - provided
-        - provided.al2023
       Description: 'Layer for AWS Lambda Adapter x86_64'
       LicenseInfo: 'Available under the Apache-2.0 license.'
       RetentionPolicy: Retain


### PR DESCRIPTION
The 'CompatibleRuntimes' property is limited to 15 values and optional. People can add this layer using the layer ARN.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
