### PR TITLE
Specify correct platform when building docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ clean:
 	rm -rf target
 
 build-builder-x86:
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile.builder --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/rust-builder:latest-x86_64 .
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile.builder --platform linux/amd64 --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/rust-builder:latest-x86_64 .
 
 build-builder-arm64:
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile.builder --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/rust-builder:latest-aarch64 .
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile.builder --platform linux/arm64 --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/rust-builder:latest-aarch64 .
 
 build-builder: build-builder-x86 build-builder-arm64
 	docker push public.ecr.aws/awsguru/rust-builder:latest-x86_64
@@ -22,10 +22,10 @@ publish-builder:
 	docker manifest push public.ecr.aws/awsguru/rust-builder:latest
 
 build-x86:
-	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/amd64 --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-x86_64 .
+	DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg TARGET_PLATFORM=linux/amd64 --build-arg ARCH=x86_64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-x86_64 .
 
 build-arm:
-	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-aarch64 .
+	DOCKER_BUILDKIT=1 docker build --platform linux/arm64 --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -t public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-aarch64 .
 
 build: build-x86 build-arm
 	docker push public.ecr.aws/awsguru/aws-lambda-adapter:$(CARGO_PKG_VERSION)-x86_64
@@ -41,15 +41,15 @@ publish:
 
 build-mac:
 	CC=x86_64-unknown-linux-musl-gcc cargo build --release --target=x86_64-unknown-linux-musl
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile.mac --build-arg ARCH=x86_64 -t aws-lambda-adapter:latest .
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile.mac --platform linux/amd64 --build-arg ARCH=x86_64 -t aws-lambda-adapter:latest .
 
 build-LambdaAdapterLayerX86:
 	cp layer/* $(ARTIFACTS_DIR)/
-	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/amd64 --build-arg ARCH=x86_64 -o $(ARTIFACTS_DIR)/extensions .
+	DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg TARGET_PLATFORM=linux/amd64 --build-arg ARCH=x86_64 -o $(ARTIFACTS_DIR)/extensions .
 
 build-LambdaAdapterLayerArm64:
 	cp layer/* $(ARTIFACTS_DIR)/
-	DOCKER_BUILDKIT=1 docker build --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -o $(ARTIFACTS_DIR)/extensions .
+	DOCKER_BUILDKIT=1 docker build --platform linux/arm64 --build-arg TARGET_PLATFORM=linux/arm64 --build-arg ARCH=aarch64 -o $(ARTIFACTS_DIR)/extensions .
 
 fmt:
 	cargo fmt --all


### PR DESCRIPTION
*Issue #, if available:*

fix #311 

*Description of changes:*

Add correct platform parameters when building docker images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
