### PR TITLE
Release v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "lambda_web_adapter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_web_adapter"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "Harold Sun <sunhua@amazon.com>",
     "David Calavera <dcalaver@amazon.com>",


### PR DESCRIPTION
*Description of changes:*

Release the new version 0.8.1. This release contains the fix for passing through Bedrock Agent events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
