### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Use LF rather than CRLF line endings on shell scripts checked out to Windows clients otherwise they give errors after 'sam build' / 'sam deploy'
 *.sh text eol=lf
+bootstrap text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use LF rather than CRLF line endings on shell scripts checked out to Windows clients otherwise they give errors after 'sam build' / 'sam deploy'
+*.sh text eol=lf


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Create .gitattributes file

I use Windows. I found that when pulling down this repo, the LF characters are changed to CRLF (which is default git behaviour on Windows). This caused a problem with .sh files, since SAM build/deploy does not change CRLF back to LF, and the CRLF causes .sh scripts to fail.

Specifically, I was using the expressjs-zip example, and the error was ```/var/task/run.sh: /bin/bash^M: bad interpreter: No such file or directory```

This .gitattribute file tells git not to change LF to CRLF for .sh files. With this file added, syncing the repo and using SAM to build/deploy the expressjs-zip example works correctly.

It also tells git to use LF rather than CRLF for bootstrap files, for the same reason (required for the nginx-zip example).

References:
- https://stackoverflow.com/questions/14219092/bash-script-bin-bashm-bad-interpreter-no-such-file-or-directory
- https://stackoverflow.com/questions/20496084/git-status-ignore-line-endings-in-identical-files-on-windows-linux

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
