### PR TITLE
Update BuildMethod in gin-zip example

### DIFF
--- a/examples/gin-zip/app/Makefile
+++ b/examples/gin-zip/app/Makefile
@@ -1,3 +1,0 @@
-build-GinFunction:
-	GOOS=linux CGO_ENABLED=0 go build -o bootstrap .
-	mv bootstrap $(ARTIFACTS_DIR)/bootstrap

--- a/examples/gin-zip/template.yaml
+++ b/examples/gin-zip/template.yaml
@@ -27,7 +27,7 @@ Resources:
         APIEvent:
           Type: HttpApi
     Metadata:
-       BuildMethod: makefile
+       BuildMethod: go1.x
 
 Outputs:
   GinApi:


### PR DESCRIPTION
*Description of changes:*

Use the build-in go1.x build method supported by SAM CLI to replace the custom Makefile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
