### PR TITLE
Support UTF-8 String in HTTP Header Values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5af275f3e5801892c4295a919c5edbe8d24134f91458269a77a2da12622c123"
+checksum = "4e84ed7ec0561e54444ad328c76b633f2946b77c234c99baf18c9e84250ceea1"
 dependencies = [
  "base64",
  "bytes",
@@ -1144,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacbb68e7ae5264884f114f79d4e0de33c66cb5a8f363ac93de7112f624d233d"
+checksum = "5107d9a9513f340fc9f80ec01ce88c81ab11de0a0826c9c3896504b602ae788b"
 dependencies = [
  "aws_lambda_events",
  "base64",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe297b61a7ec2041993b5c477572d18a3b311b21ae31bde6ed98687fb102ef3"
+checksum = "97113292dd7dc3a4f2ca23f6f5e32cbc02b8d54d9966f9e98111a5b3f153d582"
 dependencies = [
  "async-stream",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ http = "1.0"
 http-body = "1.0.0"
 hyper = { version = "1.0", features = ["client"] }
 hyper-util = "0.1.2"
-lambda_http = { version = "0.9.2", default-features = false, features = ["apigw_http", "apigw_rest", "alb", "pass_through"] }
+lambda_http = { version = "0.9.3", default-features = false, features = ["apigw_http", "apigw_rest", "alb", "pass_through"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = [
     "macros",


### PR DESCRIPTION
*Description of changes:*

lambda-http 0.9.3 contains support for UTF-8 header values (https://github.com/awslabs/aws-lambda-rust-runtime/pull/800)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
