### PR TITLE
Update deploy process Bedrock Agent (zip and container) using CloudFormation

### DIFF
--- a/examples/bedrock-agent-fastapi-zip/README.md
+++ b/examples/bedrock-agent-fastapi-zip/README.md
@@ -25,6 +25,44 @@ The following tools should be installed and configured.
 * [Python](https://www.python.org/)
 * [Docker](https://www.docker.com/products/docker-desktop)
 
+## Generate OpenAPI schema
+
+Before you create your agent, you should set up action groups that you want to add to your agent. When you create an action group, you must define the APIs that the agent can invoke with an OpenAPI schema in JSON or YAML format. (see [reference](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-api-schema.html))
+
+FastAPI can generate OpenAPI schema.
+
+Please install the required dependency in a virtual environment first.
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r app/requirements.txt
+pip install boto3
+cd app/
+```
+
+(in app directory)
+
+```shell
+python -c "import main;import json; print(json.dumps(main.app.openapi()))" > openapi.json
+```
+
+## Update template.yaml
+
+Update the Payload part of ActionGroups defined in template.yaml with the OpenAPI schema value.
+
+```yaml
+ApiSchema:
+    Payload: '<<Open API schema>>'
+```
+
+(in example root directory)
+
+```shell
+sed -i "s@\\\\n@\\\\\\\\\\\\\\\\n@g" app/openapi.json
+sed -i "s@<<Open API schema>>@`cat app/openapi.json`@g" template.yaml
+```
+
 ## Deploy to Lambda
 
 Navigate to the sample's folder and use the SAM CLI to build a container image
@@ -38,33 +76,8 @@ This command compiles the application and prepares a deployment package in the `
 To deploy the application in your AWS account, you can use the SAM CLI's guided deployment process and follow the instructions on the screen
 
 ```shell
-sam deploy --guided
+sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
 ```
-
-## Generate OpenAPI schema
-
-Before you create your agent, you should set up action groups that you want to add to your agent. When you create an action group, you must define the APIs that the agent can invoke with an OpenAPI schema in JSON or YAML format. (see [reference](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-api-schema.html))
-
-FastAPI can generate OpenAPI schema.
-
-Please install the required dependency in a virtual environment first.
-
-```shell
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r app/requirements.txt
-cd app/
-```
-
-(in app directory)
-
-```shell
-python -c "import main;import json; print(json.dumps(main.app.openapi()))" > openapi.json
-```
-
-## Create an agent
-
-see [reference](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html)
 
 ## Test locally
 

--- a/examples/bedrock-agent-fastapi-zip/template.yaml
+++ b/examples/bedrock-agent-fastapi-zip/template.yaml
@@ -36,7 +36,62 @@ Resources:
       SourceAccount: !Ref 'AWS::AccountId'  
       SourceArn: !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent/*  
 
+  BedrockAgentResourceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AmazonBedrockExecutionRoleForAgents_FastAPISample
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub ${AWS::AccountId}
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent/*
+      Policies:
+        - PolicyName: AmazonBedrockExecutionRoleForAgents_FastAPISamplePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: bedrock:InvokeModel
+                Resource: !Sub arn:aws:bedrock:${AWS::Region}::foundation-model/anthropic.claude-v2:1
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt BedrockAgentFastAPIFunction.Arn
+
+  BedrockAgent:
+    Type: AWS::Bedrock::Agent
+    Properties:
+      AgentName: BedrockAgentFastAPISample
+      Description: Query S3 information agent.
+      AgentResourceRoleArn: !GetAtt BedrockAgentResourceRole.Arn
+      Instruction: This agent allows you to query the S3 information in your AWS account.
+      FoundationModel: anthropic.claude-v2:1
+      ActionGroups:
+        - ActionGroupName: action-group
+          ActionGroupExecutor:
+            Lambda: !GetAtt BedrockAgentFastAPIFunction.Arn
+          ApiSchema:
+            Payload: '<<Open API schema>>'
+
+  BedrockAgentRelease:
+    Type: AWS::Bedrock::AgentAlias
+    Properties:
+      AgentAliasName: v1
+      AgentId: !Ref BedrockAgent
+
 Outputs:  
   BedrockAgentFastAPIFunction:  
     Description: "BedrockAgentFastAPIFunction Lambda Function ARN"  
     Value: !GetAtt BedrockAgentFastAPIFunction.Arn  
+  BedrockAgent:
+    Description: "BedrockAgent ID"
+    Value: !Ref BedrockAgent
+  BedrockAgentAlias:
+    Description: "BedrockAgentAlias ID"
+    Value: !Ref BedrockAgentRelease

--- a/examples/bedrock-agent-fastapi/README.md
+++ b/examples/bedrock-agent-fastapi/README.md
@@ -32,22 +32,6 @@ The following tools should be installed and configured.
 * [Python](https://www.python.org/)
 * [Docker](https://www.docker.com/products/docker-desktop)
 
-## Deploy to Lambda
-
-Navigate to the sample's folder and use the SAM CLI to build a container image
-
-```shell
-sam build
-```
-
-This command compiles the application and prepares a deployment package in the `.aws-sam` sub-directory.
-
-To deploy the application in your AWS account, you can use the SAM CLI's guided deployment process and follow the instructions on the screen
-
-```shell
-sam deploy --guided
-```
-
 ## Generate OpenAPI schema
 
 Before you create your agent, you should set up action groups that you want to add to your agent. When you create an action group, you must define the APIs that the agent can invoke with an OpenAPI schema in JSON or YAML format. (see [reference](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-api-schema.html))
@@ -69,11 +53,37 @@ cd app/
 python -c "import main;import json; print(json.dumps(main.app.openapi()))" > openapi.json
 ```
 
-## Create an agent
+## Update template.yaml
 
-see [reference](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html)
+Update the Payload part of ActionGroups defined in template.yaml with the OpenAPI schema value.
 
-## Test locally
+```yaml
+ApiSchema:
+    Payload: '<<Open API schema>>'
+```
+
+(in example root directory)
+
+```shell
+sed -i "s@\\\\n@\\\\\\\\\\\\\\\\n@g" app/openapi.json
+sed -i "s@<<Open API schema>>@`cat app/openapi.json`@g" template.yaml
+```
+
+## Deploy to Lambda
+
+Navigate to the sample's folder and use the SAM CLI to build a container image
+
+```shell
+sam build
+```
+
+This command compiles the application and prepares a deployment package in the `.aws-sam` sub-directory.
+
+To deploy the application in your AWS account, you can use the SAM CLI's guided deployment process and follow the instructions on the screen
+
+```shell
+sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
+```
 
 Sample event exists in events directory. You can test locally with bellow command.
 

--- a/examples/bedrock-agent-fastapi/template.yaml
+++ b/examples/bedrock-agent-fastapi/template.yaml
@@ -31,7 +31,62 @@ Resources:
       SourceAccount: !Ref 'AWS::AccountId'  
       SourceArn: !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent/*  
 
+  BedrockAgentResourceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AmazonBedrockExecutionRoleForAgents_FastAPISample
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub ${AWS::AccountId}
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent/*
+      Policies:
+        - PolicyName: AmazonBedrockExecutionRoleForAgents_FastAPISamplePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: bedrock:InvokeModel
+                Resource: !Sub arn:aws:bedrock:${AWS::Region}::foundation-model/anthropic.claude-v2:1
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt BedrockAgentFastAPIFunction.Arn
+
+  BedrockAgent:
+    Type: AWS::Bedrock::Agent
+    Properties:
+      AgentName: BedrockAgentFastAPISample
+      Description: Query S3 information agent.
+      AgentResourceRoleArn: !GetAtt BedrockAgentResourceRole.Arn
+      Instruction: This agent allows you to query the S3 information in your AWS account.
+      FoundationModel: anthropic.claude-v2:1
+      ActionGroups:
+        - ActionGroupName: action-group
+          ActionGroupExecutor:
+            Lambda: !GetAtt BedrockAgentFastAPIFunction.Arn
+          ApiSchema:
+            Payload: '<<Open API schema>>'
+
+  BedrockAgentRelease:
+    Type: AWS::Bedrock::AgentAlias
+    Properties:
+      AgentAliasName: v1
+      AgentId: !Ref BedrockAgent
+
 Outputs:  
   BedrockAgentFastAPIFunction:  
     Description: "BedrockAgentFastAPIFunction Lambda Function ARN"  
     Value: !GetAtt BedrockAgentFastAPIFunction.Arn  
+  BedrockAgent:
+    Description: "BedrockAgent ID"
+    Value: !Ref BedrockAgent
+  BedrockAgentAlias:
+    Description: "BedrockAgentAlias ID"
+    Value: !Ref BedrockAgentRelease


### PR DESCRIPTION
CloudFormation is now supported deploying Agents for Amazon Bedrock.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_Bedrock.html

So, I updated deploy process about sample bedrock-agent-fastapi-zip and bedrock-agent-fastapi.
