### PR TITLE
Remove "transfer-encoding" header from responses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,10 +312,6 @@ impl Adapter<HttpConnector, Body> {
             HeaderName::from_static("x-amzn-lambda-context"),
             HeaderValue::from_bytes(serde_json::to_string(&lambda_context)?.as_bytes())?,
         );
-
-        // remote hop-by-hop headers from the request
-        remove_hop_by_hop_headers(&mut req_headers);
-
         let mut app_url = self.domain.clone();
         app_url.set_path(path);
         app_url.set_query(parts.uri.query());


### PR DESCRIPTION
*Description of changes:*

This change removes "transfer-encoding" http header from web app response. This resolves an issue that `sam local start-api` fails to handle the chunked response from SpringBoot. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
