### PR TITLE
[#453] Update the Fast API run script examples to include LAMBDA_RUNTIME_DIR in search path.

### DIFF
--- a/examples/bedrock-agent-fastapi-zip/app/run.sh
+++ b/examples/bedrock-agent-fastapi-zip/app/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-PATH=$PATH:$LAMBDA_TASK_ROOT/bin:/opt/bin PYTHONPATH=$LAMBDA_RUNTIME_DIR:/opt/python exec python -m uvicorn --port=$PORT main:app
+PATH=$PATH:$LAMBDA_TASK_ROOT/bin:/opt/bin PYTHONPATH=/opt/python:$LAMBDA_RUNTIME_DIR exec python -m uvicorn --port=$PORT main:app

--- a/examples/bedrock-agent-fastapi-zip/app/run.sh
+++ b/examples/bedrock-agent-fastapi-zip/app/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-PATH=$PATH:$LAMBDA_TASK_ROOT/bin:/opt/bin PYTHONPATH=$LAMBDA_TASK_ROOT:/opt/python exec python -m uvicorn --port=$PORT main:app
+PATH=$PATH:$LAMBDA_TASK_ROOT/bin:/opt/bin PYTHONPATH=$LAMBDA_RUNTIME_DIR:/opt/python exec python -m uvicorn --port=$PORT main:app

--- a/examples/fastapi-response-streaming-zip/app/run.sh
+++ b/examples/fastapi-response-streaming-zip/app/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$LAMBDA_RUNTIME_DIR:$PYTHONPATH:/opt/python \
+    PYTHONPATH=$PYTHONPATH:/opt/python:$LAMBDA_RUNTIME_DIR \
     exec python -m uvicorn --port=$PORT main:app

--- a/examples/fastapi-response-streaming-zip/app/run.sh
+++ b/examples/fastapi-response-streaming-zip/app/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$LAMBDA_TASK_ROOT:$PYTHONPATH:/opt/python \
+    PYTHONPATH=$LAMBDA_RUNTIME_DIR:$PYTHONPATH:/opt/python \
     exec python -m uvicorn --port=$PORT main:app

--- a/examples/fastapi-zip/app/run.sh
+++ b/examples/fastapi-zip/app/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$LAMBDA_RUNTIME_DIR:$PYTHONPATH:/opt/python \
+    PYTHONPATH=$PYTHONPATH:/opt/python:$LAMBDA_RUNTIME_DIR \
     exec python -m uvicorn --port=$PORT main:app

--- a/examples/fastapi-zip/app/run.sh
+++ b/examples/fastapi-zip/app/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$LAMBDA_TASK_ROOT:$PYTHONPATH:/opt/python \
+    PYTHONPATH=$LAMBDA_RUNTIME_DIR:$PYTHONPATH:/opt/python \
     exec python -m uvicorn --port=$PORT main:app

--- a/examples/flask-zip/app/run.sh
+++ b/examples/flask-zip/app/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$LAMBDA_TASK_ROOT:$PYTHONPATH:/opt/python \
+    PYTHONPATH=$LAMBDA_RUNTIME_DIR:$PYTHONPATH:/opt/python \
     exec python -m gunicorn -b=:$PORT -w=1 app:app

--- a/examples/flask-zip/app/run.sh
+++ b/examples/flask-zip/app/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$LAMBDA_RUNTIME_DIR:$PYTHONPATH:/opt/python \
+    PYTHONPATH=$PYTHONPATH:/opt/python:$LAMBDA_RUNTIME_DIR \
     exec python -m gunicorn -b=:$PORT -w=1 app:app


### PR DESCRIPTION
*Issue #, if available:* #453

*Description of changes:* Update the Fast API run script examples

After the change, the search path has been verified to be `['', '/var/task', '/var/runtime', '/var/lang/lib/python38.zip', '/var/lang/lib/python3.8', '/var/lang/lib/python3.8/lib-dynload', '/var/lang/lib/python3.8/site-packages']`, where `/var/runtime` is the value of `$LAMBDA_RUNTIME_DIR` and the code could work even user didn't bundle boto3 in the zip archive.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
