### PR TITLE
add authorization_source feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The readiness check port/path and traffic port can be configured using environme
 | AWS_LWA_ENABLE_COMPRESSION                                   | enable gzip compression for response body                                            | "false"    |
 | AWS_LWA_INVOKE_MODE                                          | Lambda function invoke mode: "buffered" or "response_stream", default is "buffered"  | "buffered" |
 | AWS_LWA_PASS_THROUGH_PATH                                    | the path for receiving event payloads that are passed through from non-http triggers | "/events"  |
+| AWS_LWA_AUTHORIZATION_SOURCE                                 | a header name to be replaced to `Authorization` | None  |
 
 > **Note:**
 > We use "AWS_LWA_" prefix to namespacing all environment variables used by Lambda Web Adapter. The original ones will be supported until we reach version 1.0.
@@ -133,6 +134,8 @@ Please check out [FastAPI with Response Streaming](examples/fastapi-response-str
 **AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS** - allows you to customize which HTTP status codes are considered healthy and which ones are not
 
 **AWS_LWA_PASS_THROUGH_PATH** - Path to receive events payloads passed through from non-http event triggers. The default is "/events".
+
+**AWS_LWA_AUTHORIZATION_SOURCE** - When set, Lambda Web Adapter replaces the specified header name to `Authorization` before proxying a request. This is useful when you use Lambda function URL with [IAM auth type](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html), which reserves Authorization header for IAM authentication, but you want to still use Authorization header for your backend apps. This feature is disabled by default.
 
 ## Request Context
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub struct AdapterOptions {
     pub async_init: bool,
     pub compression: bool,
     pub invoke_mode: LambdaInvokeMode,
+    pub authorization_source: String,
 }
 
 impl Default for AdapterOptions {
@@ -114,6 +115,10 @@ impl Default for AdapterOptions {
                 .unwrap_or("buffered".to_string())
                 .as_str()
                 .into(),
+            authorization_source: env::var("AWS_LWA_AUTHORIZATION_SOURCE")
+                .unwrap_or("".to_string())
+                .as_str()
+                .into(),
         }
     }
 }
@@ -131,6 +136,7 @@ pub struct Adapter<C, B> {
     path_through_path: String,
     compression: bool,
     invoke_mode: LambdaInvokeMode,
+    authorization_source: String,
 }
 
 impl Adapter<HttpConnector, Body> {
@@ -167,6 +173,7 @@ impl Adapter<HttpConnector, Body> {
             ready_at_init: Arc::new(AtomicBool::new(false)),
             compression: options.compression,
             invoke_mode: options.invoke_mode,
+            authorization_source: options.authorization_source.clone(),
         }
     }
 }
@@ -312,6 +319,12 @@ impl Adapter<HttpConnector, Body> {
             HeaderName::from_static("x-amzn-lambda-context"),
             HeaderValue::from_bytes(serde_json::to_string(&lambda_context)?.as_bytes())?,
         );
+
+        if !self.authorization_source.is_empty() && req_headers.contains_key(&self.authorization_source) {
+            let original = req_headers.remove(&self.authorization_source).unwrap();
+            req_headers.insert("authorization", original);
+        }
+
         let mut app_url = self.domain.clone();
         app_url.set_path(path);
         app_url.set_query(parts.uri.query());

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -56,7 +56,7 @@ fn test_adapter_options_from_env() {
     assert!(options.async_init);
     assert!(options.compression);
     assert_eq!(LambdaInvokeMode::Buffered, options.invoke_mode);
-    assert_eq!("auth-token", options.authorization_source);
+    assert_eq!(Some("auth-token".into()), options.authorization_source);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn test_adapter_options_from_namespaced_env() {
     assert!(options.async_init);
     assert!(options.compression);
     assert_eq!(LambdaInvokeMode::ResponseStream, options.invoke_mode);
-    assert_eq!("auth-token", options.authorization_source);
+    assert_eq!(Some("auth-token".into()), options.authorization_source);
 }
 
 #[test]
@@ -626,7 +626,7 @@ async fn test_http_authorization_source() {
         port: app_server.port().to_string(),
         readiness_check_port: app_server.port().to_string(),
         readiness_check_path: "/healthcheck".to_string(),
-        authorization_source: "auth-token".to_string(),
+        authorization_source: Some("auth-token".to_string()),
         ..Default::default()
     });
 

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -41,6 +41,7 @@ fn test_adapter_options_from_env() {
     env::set_var("AWS_LWA_TLS_SERVER_NAME", "api.example.com");
     env::remove_var("AWS_LWA_TLS_CERT_FILE");
     env::set_var("AWS_LWA_INVOKE_MODE", "buffered");
+    env::set_var("AWS_LWA_AUTHORIZATION_SOURCE", "auth-token");
 
     // Initialize adapter with env options
     let options = AdapterOptions::default();
@@ -55,6 +56,7 @@ fn test_adapter_options_from_env() {
     assert!(options.async_init);
     assert!(options.compression);
     assert_eq!(LambdaInvokeMode::Buffered, options.invoke_mode);
+    assert_eq!("auth-token", options.authorization_source);
 }
 
 #[test]
@@ -69,6 +71,7 @@ fn test_adapter_options_from_namespaced_env() {
     env::set_var("AWS_LWA_ASYNC_INIT", "true");
     env::set_var("AWS_LWA_ENABLE_COMPRESSION", "true");
     env::set_var("AWS_LWA_INVOKE_MODE", "response_stream");
+    env::set_var("AWS_LWA_AUTHORIZATION_SOURCE", "auth-token");
 
     // Initialize adapter with env options
     let options = AdapterOptions::default();
@@ -84,6 +87,7 @@ fn test_adapter_options_from_namespaced_env() {
     assert!(options.async_init);
     assert!(options.compression);
     assert_eq!(LambdaInvokeMode::ResponseStream, options.invoke_mode);
+    assert_eq!("auth-token", options.authorization_source);
 }
 
 #[test]
@@ -605,6 +609,47 @@ async fn test_http_content_encoding_suffix() {
         response.headers().get("content-type").unwrap()
     );
     assert_eq!(json_data.to_owned(), body_to_string(response).await);
+}
+
+#[tokio::test]
+async fn test_http_authorization_source() {
+    // Start app server
+    let app_server = MockServer::start();
+    let hello = app_server.mock(|when, then| {
+        when.method(GET).path("/hello").header_exists("Authorization");
+        then.status(200).body("Hello World");
+    });
+
+    // Initialize adapter
+    let mut adapter = Adapter::new(&AdapterOptions {
+        host: app_server.host(),
+        port: app_server.port().to_string(),
+        readiness_check_port: app_server.port().to_string(),
+        readiness_check_path: "/healthcheck".to_string(),
+        authorization_source: "auth-token".to_string(),
+        ..Default::default()
+    });
+
+    // // Call the adapter service with basic request
+    let req = LambdaEventBuilder::new()
+        .with_path("/hello")
+        .with_header("auth-token", "Bearer token")
+        .build();
+
+    // We convert to Request object because it allows us to add
+    // the lambda Context
+    let mut request = Request::from(req);
+    add_lambda_context_to_request(&mut request);
+
+    let response = adapter.call(request).await.expect("Request failed");
+
+    // Assert endpoint was called once
+    hello.assert();
+
+    // and response has expected content
+    assert_eq!(200, response.status());
+    assert_eq!(response.headers().get("content-length").unwrap(), "11");
+    assert_eq!("Hello World", body_to_string(response).await);
 }
 
 #[tokio::test]


### PR DESCRIPTION
*Issue #, if available:*

#477 

*Description of changes:*

Added `AWS_LWA_AUTHORIZATION_SOURCE` option to rename a specifed header name to `Authorization`. Details are in the linked issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
