### PR TITLE
warn when configured header not found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,8 @@ impl Adapter<HttpConnector, Body> {
             if req_headers.contains_key(authorization_source) {
                 let original = req_headers.remove(authorization_source).unwrap();
                 req_headers.insert("authorization", original);
+            } else {
+                tracing::warn!("\"{}\" header not found in request headers", authorization_source);
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-lambda-web-adapter/issues/477

*Description of changes:*

missed https://github.com/awslabs/aws-lambda-web-adapter/pull/478 code review

warn when:
1. `AWS_LWA_AUTHORIZATION_SOURCE=auth-token`
2. `.with_header("other-token", "Bearer token")`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
