### PR TITLE
docs: Add Web to tool name in docs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,13 +1,13 @@
 ## How does it work?
 
-AWS Lambda Adapter supports AWS Lambda function triggered by Amazon API Gateway Rest API, Http API(v2 event format), and Application Load Balancer.
-Lambda Adapter converts incoming events to http requests and send to web application, and convert the http response back to lambda event response.
+AWS Lambda Web Adapter supports AWS Lambda functions triggered by Amazon API Gateway Rest API, Http API (v2 event format), and Application Load Balancer.
+Lambda Web Adapter converts incoming events to http requests and sends to web application, and converts the http response back to lambda event response.
 
-Lambda Adapter is a Lambda Extension (since 0.2.0). When the docker image is running inside AWS Lambda Service, Lambda will automatic start the Adapter and 
-the runtime process. When running outside of Lambda, Lambda Adapter does not run at all. This allows developers to package their web application 
+Lambda Web Adapter is a Lambda Extension (since 0.2.0). When the docker image is running inside AWS Lambda Service, Lambda will automatic start the Adapter and 
+the runtime process. When running outside of Lambda, Lambda Web Adapter does not run at all. This allows developers to package their web application 
 as a container image and run it on AWS Lambda, AWS Fargate and Amazon EC2 without changing code.
 
-After Lambda Adapter launch the application, it will perform readiness check on http://localhost:8080/ every 10ms.
+After Lambda Web Adapter launches the application, it will perform readiness check on http://localhost:8080/ every 10ms.
 It will start lambda runtime client after receiving 200 response from the application and forward requests to http://localhost:8080.
 
 ![lambda-runtime](images/lambda-adapter-runtime.png)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 ## How to build it?
 
-AWS Lambda Adapter is written in Rust and based on [AWS Lambda Rust Runtime](https://github.com/awslabs/aws-lambda-rust-runtime).
+AWS Lambda Web Adapter is written in Rust and based on [AWS Lambda Rust Runtime](https://github.com/awslabs/aws-lambda-rust-runtime).
 AWS Lambda executes functions in x86_64 Amazon Linux Environment. We need to compile the adapter to that environment.
 
 ### Clone the repo
@@ -13,7 +13,7 @@ $ cd aws-lambda-adapter
 ```
 
 ### Compiling with Docker
-On x86_64 Windows, Linux and macOS, you can run one command to compile Lambda Adapter with docker.
+On x86_64 Windows, Linux and macOS, you can run one command to compile Lambda Web Adapter with docker.
 The Dockerfile is [here](../Dockerfile). [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) should have been installed and configured.
 
 ```shell
@@ -24,7 +24,7 @@ Once the build completes, it creates two docker images:
 - "aws-lambda-adapter:latest-x86_64" for x86_64.
 - "aws-lambda-adapter:latest-aarch64" for arm64.
 
-AWS Lambda Adapter binary is packaged as '/opt/bootstrap' inside each docker image. "aws-lambda-adapter:latest" is tagged to the same image as "aws-lambda-adapter:latest-x86_64".
+AWS Lambda Web Adapter binary is packaged as '/opt/bootstrap' inside each docker image. "aws-lambda-adapter:latest" is tagged to the same image as "aws-lambda-adapter:latest-x86_64".
 
 ### Compiling on macOS
 
@@ -56,15 +56,15 @@ linker = "x86_64-unknown-linux-musl-gcc"
 linker = "aarch64-unknown-linux-musl-gcc"'> .cargo/config
 ```
 
-Now we can cross compile AWS Lambda Adapter.
+Now we can cross compile AWS Lambda Web Adapter.
 
 ```shell
 $ CC=x86_64-unknown-linux-musl-gcc cargo build --release --target=x86_64-unknown-linux-musl --features vendored
 $ CC=aarch64-unknown-linux-musl-gcc cargo build --release --target=aarch64-unknown-linux-musl --features vendored
 ```
 
-Lambda Adapter binary for x86_64 will be placed at `target/x86_64-unknown-linux-musl/release/bootstrap`.
-Lambda Adapter binary for arm64 will be placed at `target/aarch64-unknown-linux-musl/release/bootstrap`.
+Lambda Web Adapter binary for x86_64 will be placed at `target/x86_64-unknown-linux-musl/release/bootstrap`.
+Lambda Web Adapter binary for arm64 will be placed at `target/aarch64-unknown-linux-musl/release/bootstrap`.
 
 Finally, run the following command to package lambda adapter into two container images for x86_64 and aarch64.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Changing docs where it mentioned "Lambda Adapter" instead of the official name now "Lambda Web Adapter".
- Fixing a couple of minor grammatical errors. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
