### PR TITLE
Upgrade rustsec/audit-check action to v2.0.0

### DIFF
--- a/.github/workflows/security_audit.yaml
+++ b/.github/workflows/security_audit.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: rustsec/audit-check@v1.4.1
+      - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Description of changes:*

Audit check is failing due to a GitHub Search API change. Upgrade rustsec/audit-check action to newer version to solve that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
