### PR TITLE
Update HttpBingFunction runtime

### DIFF
--- a/tests/e2e_tests/fixtures/go-httpbin-zip/template.yaml
+++ b/tests/e2e_tests/fixtures/go-httpbin-zip/template.yaml
@@ -59,7 +59,7 @@ Resources:
     Properties:
       CodeUri: ./app
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 256
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update HttpBingFunction runtime to provided.al2023. This fixes the faling e2e tests in the pipeline. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
