### PR TITLE
Add the ability to strip certain response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ The readiness check port/path and traffic port can be configured using environme
 | AWS_LWA_INVOKE_MODE                                          | Lambda function invoke mode: "buffered" or "response_stream", default is "buffered"  | "buffered" |
 | AWS_LWA_PASS_THROUGH_PATH                                    | the path for receiving event payloads that are passed through from non-http triggers | "/events"  |
 | AWS_LWA_AUTHORIZATION_SOURCE                                 | a header name to be replaced to `Authorization` | None  |
-| AWS_LWA_ERROR_STATUS_CODES                                  | comma-separated list of HTTP status codes that will cause Lambda invocations to fail (e.g. "500,502-504,422") | None  |
-| AWS_LWA_LAMBDA_RUNTIME_API_PROXY                              | overwrites `AWS_LAMBDA_RUNTIME_API` to allow proxying request (not affecting registration)                    | None       |
+| AWS_LWA_ERROR_STATUS_CODES                                   | comma-separated list of HTTP status codes that will cause Lambda invocations to fail (e.g. "500,502-504,422") | None  |
+| AWS_LWA_LAMBDA_RUNTIME_API_PROXY                             | overwrites `AWS_LAMBDA_RUNTIME_API` to allow proxying request (not affecting registration)                    | None       |
+| AWS_LWA_STRIP_RESPONSE_HEADERS                               | comma-separated list of HTTP response headers to remove from responses               | None       |
 
 > **Note:**
 > We use "AWS_LWA_" prefix to namespacing all environment variables used by Lambda Web Adapter. The original ones will be supported until we reach version 1.0.
@@ -132,6 +133,8 @@ When enabled, this will compress responses unless it's an image as determined by
 
 **AWS_LWA_INVOKE_MODE** - Lambda function invoke mode, this should match Function Url invoke mode. The default is "buffered". When configured as "response_stream", Lambda Web Adapter will stream response to Lambda service [blog](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/).
 Please check out [FastAPI with Response Streaming](examples/fastapi-response-streaming) example.
+
+**AWS_LWA_STRIP_RESPONSE_HEADERS** - Allows you to specify a list of HTTP response headers that should be removed from responses before they are sent back to the client. This is useful when you want to prevent certain headers from being exposed or when you need to override headers set by your web application framework. For example, setting `AWS_LWA_STRIP_RESPONSE_HEADERS=x-powered-by,server` will remove the `X-Powered-By` and `Server` headers from all responses. Multiple headers should be specified as a comma-separated list.
 
 **AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS** - allows you to customize which HTTP status codes are considered healthy and which ones are not
 

--- a/tests/integ_tests/main.rs
+++ b/tests/integ_tests/main.rs
@@ -750,6 +750,62 @@ async fn test_http_context_multi_headers() {
     assert_eq!("OK", body_to_string(response).await);
 }
 
+#[tokio::test]
+async fn test_http_strip_response_headers() {
+    // Start app server
+    let app_server = MockServer::start();
+
+    // An endpoint that returns multiple headers
+    let test_endpoint = app_server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200)
+            .header("x-custom-header", "value")
+            .header("server", "test-server")
+            .header("content-type", "application/json")
+            .body("{}");
+    });
+
+    // Initialize adapter with headers to strip
+    let mut adapter = Adapter::new(&AdapterOptions {
+        host: app_server.host(),
+        port: app_server.port().to_string(),
+        readiness_check_port: app_server.port().to_string(),
+        readiness_check_path: "/healthcheck".to_string(),
+        strip_response_headers: Some(vec!["x-custom-header".to_string(), "server".to_string()]),
+        ..Default::default()
+    });
+
+    // Prepare request
+    let req = LambdaEventBuilder::new().with_path("/").build();
+
+    // Convert to Request object and add Lambda Context
+    let mut request = Request::from(req);
+    add_lambda_context_to_request(&mut request);
+
+    // Call the adapter service with request
+    let response = adapter.call(request).await.expect("Request failed");
+
+    // Assert endpoint was called once
+    test_endpoint.assert();
+
+    // Verify headers were stripped
+    assert!(
+        !response.headers().contains_key("x-custom-header"),
+        "x-custom-header should be stripped"
+    );
+    assert!(
+        !response.headers().contains_key("server"),
+        "server header should be stripped"
+    );
+
+    // Verify other headers remain
+    assert!(
+        response.headers().contains_key("content-type"),
+        "content-type header should remain"
+    );
+    assert_eq!("{}", body_to_string(response).await);
+}
+
 async fn body_to_string(res: Response<Incoming>) -> String {
     let body_bytes = res.collect().await.unwrap().to_bytes();
     String::from_utf8_lossy(&body_bytes).to_string()


### PR DESCRIPTION
This PR adds the ability to strip certain headers from the http response before giving it back to the client.  This can also be useful in the scenario where you want to remove HTTP1.1 headers when the client makes an HTTP2 request to the ALB.  The LWA makes an HTTP1.1 call to the process, so the server might send back headers like Connection.  The LWA gives that back to the ALB which gives Connection back to the client, but the client might reject the response since you aren't supposed to send the Connection header back for HTTP2 requests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
