### PR TITLE
Add links to Datadog examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ The `AWS_LWA_LAMBDA_RUNTIME_API_PROXY` environment varible makes the Lambda Web 
 - [Remix](examples/remix/)
 - [Remix in Zip](examples/remix-zip/)
 - [Sveltekit SSR Zip](examples/sveltekit-ssr-zip/)
+- [Datadog](examples/datadog)
+- [Datadog in Zip](examples/datadog-zip)
 
 ## Acknowledgement
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
A previous PR https://github.com/awslabs/aws-lambda-web-adapter/pull/602 added Datadog examples. The current PR adds links to the examples in README.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
