### PR TITLE
ci: declare permissions on security_audit workflow

### DIFF
--- a/.github/workflows/security_audit.yaml
+++ b/.github/workflows/security_audit.yaml
@@ -2,6 +2,11 @@ name: Security audit
 on:
   schedule:
     - cron: '0 0 * * *'
+
+permissions:
+  contents: read   # actions/checkout
+  issues: write    # rustsec/audit-check opens a tracking issue when new advisories appear
+
 jobs:
   audit:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
`security_audit.yaml` runs nightly and uses [`rustsec/audit-check`](https://github.com/rustsec/audit-check) to scan the Rust dependency tree for advisories. That action creates a GitHub issue when new advisories appear, so the workflow needs `issues: write` in addition to `contents: read` for the checkout step.