### PR TITLE
fix: update rand and rustls-webpki to resolve 4 security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,9 +1597,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

The nightly [Security audit workflow](https://github.com/aws/aws-lambda-web-adapter/actions/runs/26484130405) reported 4 advisories against transitive dependencies pinned in `Cargo.lock`. This PR is a lockfile-only bump that picks up the patches.

| Advisory | Package | 0.x.y → patched | Reachability from this crate |
|---|---|---|---|
| RUSTSEC-2026-0098 | `rustls-webpki` | `0.103.10` → `0.103.13` | Not reachable — no URI name assertions. |
| RUSTSEC-2026-0099 | `rustls-webpki` | `0.103.10` → `0.103.13` | Reachable only after misissuance (DNS wildcard name-constraint bypass). |
| RUSTSEC-2026-0104 | `rustls-webpki` | `0.103.10` → `0.103.13` | Not reachable — we don't parse CRLs. |
| RUSTSEC-2026-0097 | `rand` (unsound) | `0.8.5` → `0.8.6` | Not reachable — requires custom `log` logger calling `rand::rng()` reentrantly during reseeding. |

Both bumps are within the same SemVer minor, so no API churn for this crate.

`rustls-webpki` is pulled in via `hyper-rustls` (dev-dep). `rand` is pulled in via `tokio-retry`.

## Out of scope

The audit workflow itself emitted `Resource not accessible by integration` because it's missing `issues: write` permission. That's already being addressed in #718, so it's not part of this PR.

## Test plan

- [x] `cargo build --tests` clean
- [x] `cargo test --lib` — all 21 tests pass
- [ ] Next nightly `Security audit` run is green