### PR TITLE
ci: drop me-central-1 region and skip china-prod

### DIFF
--- a/.github/workflows/gamma.json
+++ b/.github/workflows/gamma.json
@@ -208,14 +208,6 @@
     "region": "il-central-1"
   },
   {
-    "artifacts_bucket": "aws-sam-cli-managed-gamma-pipeline-artifactsbucket-gocktfa7ukyi",
-    "cloudformation_execution_role": "arn:aws:iam::520465526641:role/aws-sam-cli-managed-gamma-CloudFormationExecutionRo-ijpEtfXuxAik",
-    "image_repository": "520465526641.dkr.ecr.me-central-1.amazonaws.com/aws-sam-cli-managed-gamma-pipeline-resources-me-central-1-imagerepository-mu9tlcadjwdu",
-    "pipeline_execution_role": "arn:aws:iam::520465526641:role/aws-sam-cli-managed-gamma-pip-PipelineExecutionRole-GuIyvn11OiCp",
-    "arm64_supported": true,
-    "region": "me-central-1"
-  },
-  {
     "artifacts_bucket": "aws-sam-cli-managed-gamma-pipeline-artifactsbucket-fymyocp1c9zu",
     "cloudformation_execution_role": "arn:aws:iam::520465526641:role/aws-sam-cli-managed-gamma-CloudFormationExecutionRo-3y7jFj4FlLPA",
     "image_repository": "520465526641.dkr.ecr.mx-central-1.amazonaws.com/aws-sam-cli-managed-gamma-pipeline-resources-mx-central-1-imagerepository-t31ceb4cv9yj",

--- a/.github/workflows/prod.json
+++ b/.github/workflows/prod.json
@@ -208,14 +208,6 @@
     "region": "il-central-1"
   },
   {
-    "artifacts_bucket": "aws-sam-cli-managed-prod-pipeline--artifactsbucket-blcxsegmht1y",
-    "cloudformation_execution_role": "arn:aws:iam::753240598075:role/aws-sam-cli-managed-prod--CloudFormationExecutionRo-57SZ80AHp7aJ",
-    "image_repository": "753240598075.dkr.ecr.me-central-1.amazonaws.com/aws-sam-cli-managed-prod-pipeline-resources-me-central-1-imagerepository-cn1orps9gm3a",
-    "pipeline_execution_role": "arn:aws:iam::753240598075:role/aws-sam-cli-managed-prod-pipe-PipelineExecutionRole-UnqPkRu0AJwt",
-    "arm64_supported": true,
-    "region": "me-central-1"
-  },
-  {
     "artifacts_bucket": "aws-sam-cli-managed-prod-pipeline--artifactsbucket-ywkcybqdkrtp",
     "cloudformation_execution_role": "arn:aws:iam::753240598075:role/aws-sam-cli-managed-prod--CloudFormationExecutionRo-lGrtFGnIo17N",
     "image_repository": "753240598075.dkr.ecr.mx-central-1.amazonaws.com/aws-sam-cli-managed-prod-pipeline-resources-mx-central-1-imagerepository-ougxbethwrke",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -624,76 +624,76 @@ jobs:
             --no-fail-on-empty-changeset \
             --role-arn ${{ matrix.cloudformation_execution_role }}
 
-  deploy-china-prod:
-    needs: [load-matrices, deploy-china-gamma, package-china-prod]
-    runs-on: ubuntu-24.04
-    environment: prod
-    strategy:
-      matrix: ${{fromJSON(needs.load-matrices.outputs.china-prod)}}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.13"
-      - uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # deploy-china-prod:
+  #   needs: [load-matrices, deploy-china-gamma, package-china-prod]
+  #   runs-on: ubuntu-24.04
+  #   environment: prod
+  #   strategy:
+  #     matrix: ${{fromJSON(needs.load-matrices.outputs.china-prod)}}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.13"
+  #     - uses: aws-actions/setup-sam@v2
+  #       with:
+  #         use-installer: true
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Assume the github runner role
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ matrix.region }}
-          role-to-assume: ${{ env.GITHUB_RUNNER_CHINA_ROLE }}
-          audience: sts.amazonaws.com.cn
+  #     - name: Assume the github runner role
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         aws-region: ${{ matrix.region }}
+  #         role-to-assume: ${{ env.GITHUB_RUNNER_CHINA_ROLE }}
+  #         audience: sts.amazonaws.com.cn
 
-      - name: Assume the china pipeline user role
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
-          role-skip-session-tagging: true
-          audience: sts.amazonaws.com.cn
-          aws-region: ${{ matrix.region }}
-          role-to-assume: ${{ matrix.pipeline_execution_role }}
+  #     - name: Assume the china pipeline user role
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+  #         aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
+  #         role-skip-session-tagging: true
+  #         audience: sts.amazonaws.com.cn
+  #         aws-region: ${{ matrix.region }}
+  #         role-to-assume: ${{ matrix.pipeline_execution_role }}
 
-      - name: Add cargo pkg version to env vars
-        run: |
-          echo "CARGO_PKG_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')" >> $GITHUB_ENV
+  #     - name: Add cargo pkg version to env vars
+  #       run: |
+  #         echo "CARGO_PKG_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: packaged-china-prod-x86_64-${{ matrix.region }}.yaml
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: packaged-china-prod-x86_64-${{ matrix.region }}.yaml
 
-      - name: Deploy x86_64 Layer to all regions in china
-        run: |
-          sam deploy --stack-name lambda-adapter-prod-x86-${{ matrix.region }} \
-            --template packaged-china-prod-x86_64-${{ matrix.region }}.yaml \
-            --parameter-overrides CargoPkgVersion=${CARGO_PKG_VERSION} \
-            --capabilities CAPABILITY_IAM \
-            --region ${{ matrix.region }} \
-            --s3-bucket ${{ matrix.artifacts_bucket }} \
-            --image-repository ${{ matrix.image_repository }} \
-            --no-fail-on-empty-changeset \
-            --role-arn ${{ matrix.cloudformation_execution_role }}
+  #     - name: Deploy x86_64 Layer to all regions in china
+  #       run: |
+  #         sam deploy --stack-name lambda-adapter-prod-x86-${{ matrix.region }} \
+  #           --template packaged-china-prod-x86_64-${{ matrix.region }}.yaml \
+  #           --parameter-overrides CargoPkgVersion=${CARGO_PKG_VERSION} \
+  #           --capabilities CAPABILITY_IAM \
+  #           --region ${{ matrix.region }} \
+  #           --s3-bucket ${{ matrix.artifacts_bucket }} \
+  #           --image-repository ${{ matrix.image_repository }} \
+  #           --no-fail-on-empty-changeset \
+  #           --role-arn ${{ matrix.cloudformation_execution_role }}
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: packaged-china-prod-arm64-${{ matrix.region }}.yaml
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: packaged-china-prod-arm64-${{ matrix.region }}.yaml
 
-      - name: Deploy arm64 Layer to supported china regions
-        if: ${{ matrix.arm64_supported }}
-        run: |
-          sam deploy --stack-name lambda-adapter-prod-arm64-${{ matrix.region }} \
-            --template packaged-china-prod-arm64-${{ matrix.region }}.yaml \
-            --parameter-overrides CargoPkgVersion=${CARGO_PKG_VERSION} \
-            --capabilities CAPABILITY_IAM \
-            --region ${{ matrix.region }} \
-            --s3-bucket ${{ matrix.artifacts_bucket }} \
-            --image-repository ${{ matrix.image_repository }} \
-            --no-fail-on-empty-changeset \
-            --role-arn ${{ matrix.cloudformation_execution_role }}
+  #     - name: Deploy arm64 Layer to supported china regions
+  #       if: ${{ matrix.arm64_supported }}
+  #       run: |
+  #         sam deploy --stack-name lambda-adapter-prod-arm64-${{ matrix.region }} \
+  #           --template packaged-china-prod-arm64-${{ matrix.region }}.yaml \
+  #           --parameter-overrides CargoPkgVersion=${CARGO_PKG_VERSION} \
+  #           --capabilities CAPABILITY_IAM \
+  #           --region ${{ matrix.region }} \
+  #           --s3-bucket ${{ matrix.artifacts_bucket }} \
+  #           --image-repository ${{ matrix.image_repository }} \
+  #           --no-fail-on-empty-changeset \
+  #           --role-arn ${{ matrix.cloudformation_execution_role }}
 
   publish-to-public-ecr:
     needs: [deploy-prod]


### PR DESCRIPTION
*Description of changes:*

The pipeline was stuck at me-central-1 gamma and already deployed to China PROD. So drop me-central-1 gamma/prod and temporarily skip china-prod.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
