### PR TITLE
ci: fix recurring Verify Examples workflow failures

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -119,7 +119,25 @@ jobs:
 
       - name: Build
         working-directory: examples/${{ matrix.example }}
-        run: sam build
+        run: |
+          # Retry to tolerate transient registry rate limits (toomanyrequests: Rate
+          # exceeded). public.ecr.aws throttles unauthenticated pulls at ~1 req/s per
+          # source IP, and the matrix runs many jobs from shared runner IPs, so bursts
+          # collide. Exponential backoff with random jitter desynchronizes retries
+          # across jobs to avoid a thundering herd re-colliding on the same boundary.
+          max_attempts=5
+          attempt=1
+          while true; do
+            if sam build; then exit 0; fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "sam build failed after ${max_attempts} attempts"
+              exit 1
+            fi
+            delay=$(( 10 * 2 ** (attempt - 1) + RANDOM % 16 ))   # ~10/20/40/80s + 0-15s jitter
+            echo "sam build failed (attempt ${attempt}/${max_attempts}), retrying in ${delay}s..."
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+          done
 
       - name: Start local API and verify
         working-directory: examples/${{ matrix.example }}
@@ -201,7 +219,25 @@ jobs:
 
       - name: Build
         working-directory: examples/${{ matrix.example }}
-        run: sam build
+        run: |
+          # Retry to tolerate transient registry rate limits (toomanyrequests: Rate
+          # exceeded). public.ecr.aws throttles unauthenticated pulls at ~1 req/s per
+          # source IP, and the matrix runs many jobs from shared runner IPs, so bursts
+          # collide. Exponential backoff with random jitter desynchronizes retries
+          # across jobs to avoid a thundering herd re-colliding on the same boundary.
+          max_attempts=5
+          attempt=1
+          while true; do
+            if sam build; then exit 0; fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "sam build failed after ${max_attempts} attempts"
+              exit 1
+            fi
+            delay=$(( 10 * 2 ** (attempt - 1) + RANDOM % 16 ))   # ~10/20/40/80s + 0-15s jitter
+            echo "sam build failed (attempt ${attempt}/${max_attempts}), retrying in ${delay}s..."
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+          done
 
       - name: Inject local layer into build output
         working-directory: examples/${{ matrix.example }}

--- a/examples/fasthtml-zip/app/requirements.txt
+++ b/examples/fasthtml-zip/app/requirements.txt
@@ -1,1 +1,1 @@
-python-fasthtml
+python-fasthtml==0.13.4

--- a/examples/fasthtml/app/requirements.txt
+++ b/examples/fasthtml/app/requirements.txt
@@ -1,1 +1,1 @@
-python-fasthtml
+python-fasthtml==0.13.4

--- a/examples/nextjs-zip/template.yaml
+++ b/examples/nextjs-zip/template.yaml
@@ -16,7 +16,7 @@ Resources:
       CodeUri: app/
       MemorySize: 256
       Handler: run.sh
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Architectures:
         - x86_64
       Environment:

--- a/examples/remix-zip/template.yaml
+++ b/examples/remix-zip/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: run.sh
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       MemorySize: 1024
       Architectures:
         - x86_64


### PR DESCRIPTION
## Summary

The **Verify Examples** workflow (`.github/workflows/examples.yaml`) has been failing on essentially every run (push and Dependabot PRs alike). Analysis across many recent runs showed the failures are not a single flake but **three independent root causes**, addressed here:

### 1. `validate` job — EOL runtime lint failure (deterministic)
`examples/nextjs-zip` and `examples/remix-zip` pinned `Runtime: nodejs20.x`, which reached end-of-life on 2026-04-30. `sam validate --lint` therefore matched cfn-lint rule **W2531** and failed on every run.

- Bumped both templates to `nodejs22.x`.
- EOL deprecations are intentionally left to fail CI so example runtimes get updated promptly as they age out (no lint suppression added).

### 2. `test-image(fasthtml)` / `test-zip(fasthtml-zip)` — `NameError: Card` (deterministic)
`examples/fasthtml/app/requirements.txt` and `examples/fasthtml-zip/app/requirements.txt` left `python-fasthtml` unpinned. Releases `>=0.14.0` dropped `Card` from `fasthtml.common`, so the app raised `NameError: name 'Card' is not defined` and returned HTTP 500, failing the verify step.

- Pinned to `python-fasthtml==0.13.4` — the latest release that still exports `Card` **and** installs cleanly on `python:3.12-slim`.
- Verified end-to-end: the real app's index route returns **HTTP 200** with `0.13.4`.

### 3. `test-image` / `test-zip` build steps — `toomanyrequests: Rate exceeded` (intermittent)
`sam build` pulls base images from `public.ecr.aws`, which throttles unauthenticated pulls at ~1 req/s per source IP. The matrix runs many jobs from shared runner IPs, so concurrent pulls burst past the limit and 429.

- Wrapped both `sam build` invocations in a retry loop with **exponential backoff and random jitter** (~10/20/40/80s + 0–15s), so retries across jobs desynchronize and avoid a thundering herd re-colliding on the same boundary.

## Verification
- `python-fasthtml==0.13.4`: clean install on `python:3.12-slim`; the actual `fasthtml` app returns HTTP 200 (Card renders as `<article>`).
- `nodejs22.x`: no other example template currently triggers W2531, so `validate` goes green.
- Backoff/jitter arithmetic validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)