### PR TITLE
docs: update all docs and examples for v1.0.1 release

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -115,7 +115,7 @@ jobs:
         run: |
           chmod +x /tmp/layer-x86_64/lambda-adapter
           printf 'FROM scratch\nCOPY --chmod=755 lambda-adapter /lambda-adapter\n' | \
-            docker build -t public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 -f- /tmp/layer-x86_64
+            docker build -t public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 -f- /tmp/layer-x86_64
 
       - name: Build
         working-directory: examples/${{ matrix.example }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v1.0.1 - 2026-05-28
+
+### Bug Fixes
+
+- Sanitize control bytes in `x-amzn-{request,lambda}-context` headers (#734)
+- Use the original `AWS_LAMBDA_RUNTIME_API` for extension registration (#737)
+- Update `rand` and `rustls-webpki` to resolve 4 security advisories (#736)
+
+### Documentation
+
+- Update all docs and examples for 1.0.0 release (#689)
+
+### CI/CD
+
+- Fix commitlint workflow and post lint failures as PR comments (#735)
+- Declare permissions on `security_audit` workflow (#718)
+- Drop me-central-1 region and skip china-prod in the release pipeline (#744)
+
+---
+
 ## v1.0.0 - 2026-03-27
 
 ### Major Updates

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The same docker image can run on AWS Lambda, Amazon EC2, AWS Fargate, and local 
 Add one line to your Dockerfile:
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 Pre-compiled multi-arch images (x86_64 and arm64) are available at [public.ecr.aws/awsguru/aws-lambda-adapter](https://gallery.ecr.aws/awsguru/aws-lambda-adapter). [Non-AWS base images](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html) may be used since the [Runtime Interface Client](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-ric) ships with the Lambda Web Adapter.
@@ -40,8 +40,8 @@ Pre-compiled multi-arch images (x86_64 and arm64) are available at [public.ecr.a
 ### Zip Packages
 
 1. Attach the Lambda Web Adapter layer to your function:
-   - x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-   - arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+   - x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+   - arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. Set environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`
 3. Set function handler to your startup script, e.g. `run.sh`
 

--- a/docs/guide/src/getting-started/docker-images.md
+++ b/docs/guide/src/getting-started/docker-images.md
@@ -3,7 +3,7 @@
 To use Lambda Web Adapter with Docker images, package your web app in a Dockerfile and add one line to copy the adapter binary:
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 [Non-AWS base images](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html) can be used since the [Runtime Interface Client](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-ric) ships with the adapter.
@@ -12,7 +12,7 @@ COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/node:20-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=7000
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json
@@ -37,5 +37,5 @@ ENV AWS_LWA_PORT=3000
 Pre-compiled multi-arch images (x86_64 and arm64) are available at:
 
 ```
-public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0
+public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1
 ```

--- a/docs/guide/src/getting-started/quick-start.md
+++ b/docs/guide/src/getting-started/quick-start.md
@@ -14,7 +14,7 @@ AWS Lambda Web Adapter works with Lambda functions packaged as both Docker image
 Add one line to your existing Dockerfile:
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 That's it. Your web app now runs on Lambda.

--- a/docs/guide/src/getting-started/zip-packages.md
+++ b/docs/guide/src/getting-started/zip-packages.md
@@ -10,15 +10,15 @@ AWS Lambda Web Adapter works with AWS managed Lambda runtimes via Lambda Layers.
 
 | Architecture | Layer ARN |
 |-------------|-----------|
-| x86_64 | `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27` |
-| arm64 | `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27` |
+| x86_64 | `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28` |
+| arm64 | `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28` |
 
 #### AWS China Regions
 
 | Region | Architecture | Layer ARN |
 |--------|-------------|-----------|
-| cn-north-1 (Beijing) | x86_64 | `arn:aws-cn:lambda:cn-north-1:041581134020:layer:LambdaAdapterLayerX86:27` |
-| cn-northwest-1 (Ningxia) | x86_64 | `arn:aws-cn:lambda:cn-northwest-1:069767869989:layer:LambdaAdapterLayerX86:27` |
+| cn-north-1 (Beijing) | x86_64 | `arn:aws-cn:lambda:cn-north-1:041581134020:layer:LambdaAdapterLayerX86:28` |
+| cn-northwest-1 (Ningxia) | x86_64 | `arn:aws-cn:lambda:cn-northwest-1:069767869989:layer:LambdaAdapterLayerX86:28` |
 
 ### 2. Set the Exec Wrapper
 
@@ -42,7 +42,7 @@ Resources:
       Runtime: nodejs20.x
       Handler: run.sh
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Environment:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap

--- a/examples/aspnet-mvc-zip/README.md
+++ b/examples/aspnet-mvc-zip/README.md
@@ -17,7 +17,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           RUST_LOG: info
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         Api:
           Type: HttpApi

--- a/examples/aspnet-mvc-zip/template.yaml
+++ b/examples/aspnet-mvc-zip/template.yaml
@@ -1,4 +1,4 @@
-﻿AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
 Globals:
@@ -22,7 +22,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           RUST_LOG: info
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         Api:
           Type: HttpApi

--- a/examples/aspnet-mvc/README.md
+++ b/examples/aspnet-mvc/README.md
@@ -23,7 +23,7 @@ RUN dotnet publish "AspNetLambdaWebAdapter.csproj" -c Release -o /app/publish
 
 FROM base AS final
 ENV ASPNETCORE_URLS=http://+:8080
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "AspNetLambdaWebAdapter.dll"]
@@ -32,7 +32,7 @@ ENTRYPOINT ["dotnet", "AspNetLambdaWebAdapter.dll"]
 Line 12 copies lambda adapter binary into /opt/extensions. This is required to run ASP.NET application on Lambda. The `ASPNETCORE_URLS` environment variable is also set to 8080. This is required for the Lambda Web Adapter to work.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/aspnet-mvc/src/Dockerfile
+++ b/examples/aspnet-mvc/src/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview as base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview as base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-preview AS build
@@ -12,7 +12,7 @@ RUN dotnet publish "AspNetLambdaWebAdapter.csproj" -c Release -o /app/publish
 
 FROM base AS final
 ENV ASPNETCORE_URLS=http://+:<port>
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "AspNetLambdaWebAdapter.dll"]

--- a/examples/aspnet-webapi-zip/README.md
+++ b/examples/aspnet-webapi-zip/README.md
@@ -17,7 +17,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           RUST_LOG: info
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         Api:
           Type: HttpApi

--- a/examples/aspnet-webapi-zip/template.yaml
+++ b/examples/aspnet-webapi-zip/template.yaml
@@ -1,4 +1,4 @@
-﻿AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
 Globals:
@@ -22,7 +22,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           RUST_LOG: info
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         Api:
           Type: HttpApi

--- a/examples/bedrock-agent-fastapi-zip/template.yaml
+++ b/examples/bedrock-agent-fastapi-zip/template.yaml
@@ -24,7 +24,7 @@ Resources:
           AWS_LWA_READINESS_CHECK_PROTOCOL: TCP
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Policies: AmazonS3ReadOnlyAccess
 
   BedrockAgentPermission:  

--- a/examples/bedrock-agent-fastapi/README.md
+++ b/examples/bedrock-agent-fastapi/README.md
@@ -8,7 +8,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is an Fas
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.12.0-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000 AWS_LWA_READINESS_CHECK_PROTOCOL=tcp 
 WORKDIR /var/task
 COPY requirements.txt ./
@@ -20,7 +20,7 @@ CMD exec uvicorn --port=$PORT main:app
 Line 2 copies lambda adapter binary into /opt/extensions. This is the only change to run the FastAPI application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/bedrock-agent-fastapi/app/Dockerfile
+++ b/examples/bedrock-agent-fastapi/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12.0-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000 AWS_LWA_READINESS_CHECK_PROTOCOL=tcp 
 WORKDIR /var/task
 COPY requirements.txt ./

--- a/examples/bun-graphql-streaming-zip/template.yaml
+++ b/examples/bun-graphql-streaming-zip/template.yaml
@@ -26,7 +26,7 @@ Resources:
           AWS_LWA_INVOKE_MODE: response_stream
           PORT: 3000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28
         - !Sub arn:aws:lambda:us-east-1:582637575117:layer:BunRuntimeArm64:1
       FunctionUrlConfig:
         AuthType: NONE

--- a/examples/bun-graphql-zip/template.yaml
+++ b/examples/bun-graphql-zip/template.yaml
@@ -25,7 +25,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           PORT: 3000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
         - !Sub arn:aws:lambda:us-east-1:582637575117:layer:BunRuntimeX64:1
       Events:
         RootEvent:

--- a/examples/datadog-zip/expressjs/cdk/app/cdk.ts
+++ b/examples/datadog-zip/expressjs/cdk/app/cdk.ts
@@ -41,7 +41,7 @@ class LwaStack extends Stack {
     const lwa_lambda_layer = lambda.LayerVersion.fromLayerVersionArn(
       this,
       "lwa_lambda-layer",
-      "arn:aws:lambda:us-east-1:753240598075:layer:LambdaAdapterLayerX86:27",
+      "arn:aws:lambda:us-east-1:753240598075:layer:LambdaAdapterLayerX86:28",
     );
     const dd_layer = lambda.LayerVersion.fromLayerVersionArn(
       this,

--- a/examples/datadog/expressjs-streaming/lambda-asset/Dockerfile
+++ b/examples/datadog/expressjs-streaming/lambda-asset/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/docker/library/node:slim
 
 # APM support for responsestreaming mode requires v84+
 COPY --from=public.ecr.aws/datadog/lambda-extension:84 /opt/. /opt/
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 EXPOSE 8080
 WORKDIR "/var/task"

--- a/examples/datadog/expressjs/lambda-asset/Dockerfile
+++ b/examples/datadog/expressjs/lambda-asset/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/node:slim
 
 COPY --from=public.ecr.aws/datadog/lambda-extension:84 /opt/. /opt/
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 EXPOSE 8080
 WORKDIR "/var/task"

--- a/examples/datadog/flask/lambda-asset/Dockerfile
+++ b/examples/datadog/flask/lambda-asset/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/python:slim
 
 COPY --from=public.ecr.aws/datadog/lambda-extension:84 /opt/. /opt/
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 EXPOSE 8080
 WORKDIR "/var/task"

--- a/examples/deno-zip/README.md
+++ b/examples/deno-zip/README.md
@@ -19,7 +19,7 @@ We use `java11` runtime to get SnapStart support with one caveat: no runtime hoo
       Architectures:
         - x86_64
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       MemorySize: 512
       Environment:
         Variables:

--- a/examples/deno-zip/template.yaml
+++ b/examples/deno-zip/template.yaml
@@ -24,7 +24,7 @@ Resources:
       Architectures:
         - x86_64
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       MemorySize: 512
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:

--- a/examples/expressjs-zip/README.md
+++ b/examples/expressjs-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Adapter to run an express.js application on
 We add Lambda Adapter layer to the function and configure wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 

--- a/examples/expressjs-zip/template.yaml
+++ b/examples/expressjs-zip/template.yaml
@@ -25,7 +25,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           RUST_LOG: info
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         RootPath:
           Type: Api

--- a/examples/expressjs/README.md
+++ b/examples/expressjs/README.md
@@ -10,7 +10,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is an exp
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/node:16.13.2-stretch-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 EXPOSE 8080
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json
@@ -23,7 +23,7 @@ CMD ["node", "index.js"]
 Line 2 copies lambda adapter binary into /opt/extensions. This is the only change to run the express.js application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/expressjs/app/Dockerfile
+++ b/examples/expressjs/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/node:16.13.2-stretch-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 EXPOSE 8080
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json

--- a/examples/fastapi-backend-only-response-streaming/README.md
+++ b/examples/fastapi-backend-only-response-streaming/README.md
@@ -26,7 +26,7 @@ The setup allows any frontend to consume the streaming service via GET requests 
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 WORKDIR /app
 ADD . .
@@ -38,7 +38,7 @@ CMD ["python", "main.py"]
 Notice that we only need to add the second line to install Lambda Web Adapter. 
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/
 ```
 
 In the SAM template, we use an environment variable `AWS_LWA_INVOKE_MODE: RESPONSE_STREAM` to configure Lambda Web Adapter in response streaming mode. And adding a function url with `InvokeMode: RESPONSE_STREAM`. 

--- a/examples/fastapi-backend-only-response-streaming/app/Dockerfile
+++ b/examples/fastapi-backend-only-response-streaming/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 WORKDIR /app
 ADD . .

--- a/examples/fastapi-background-tasks/README.md
+++ b/examples/fastapi-background-tasks/README.md
@@ -10,7 +10,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is a Fast
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.12-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /var/task
 COPY requirements.txt ./
@@ -22,7 +22,7 @@ CMD exec uvicorn --port=$PORT main:app
 Line 2 copies lambda web adapter binary into /opt/extensions. This is the change to run the FastAPI application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/fastapi-background-tasks/app/Dockerfile
+++ b/examples/fastapi-background-tasks/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /var/task
 COPY requirements.txt ./

--- a/examples/fastapi-response-streaming-lmi/README.md
+++ b/examples/fastapi-response-streaming-lmi/README.md
@@ -47,7 +47,7 @@ FastAPIFunction:
         AWS_LWA_INVOKE_MODE: response_stream
         PORT: 8000
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+      - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
     CapacityProviderConfig:
       Arn: !GetAtt LMICapacityProvider.Arn
       PerExecutionEnvironmentMaxConcurrency: 64

--- a/examples/fastapi-response-streaming-lmi/template.yaml
+++ b/examples/fastapi-response-streaming-lmi/template.yaml
@@ -40,7 +40,7 @@ Resources:
           AWS_LWA_INVOKE_MODE: response_stream
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       CapacityProviderConfig:
         Arn: !GetAtt LMICapacityProvider.Arn
         PerExecutionEnvironmentMaxConcurrency: 64

--- a/examples/fastapi-response-streaming-zip/README.md
+++ b/examples/fastapi-response-streaming-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Web Adapter to run a FastAPI application wi
 We add Lambda Web Adapter layer to the function and configure wrapper script.
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script.
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application.
 
@@ -30,7 +30,7 @@ This is the resource for Lambda function. The function urls's invoke mode is con
           AWS_LWA_INVOKE_MODE: response_stream
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/examples/fastapi-response-streaming-zip/template.yaml
+++ b/examples/fastapi-response-streaming-zip/template.yaml
@@ -22,7 +22,7 @@ Resources:
           AWS_LWA_INVOKE_MODE: response_stream
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/examples/fastapi-response-streaming/README.md
+++ b/examples/fastapi-response-streaming/README.md
@@ -14,7 +14,7 @@ This function is packaged as a Docker image. Here is the content of the Dockerfi
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 WORKDIR /app
 ADD . .
@@ -26,7 +26,7 @@ CMD ["python", "main.py"]
 Notice that we only need to add the second line to install Lambda Web Adapter. 
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/
 ```
 
 In the SAM template, we use an environment variable `AWS_LWA_INVOKE_MODE: RESPONSE_STREAM` to configure Lambda Web Adapter in response streaming mode. And adding a function url with `InvokeMode: RESPONSE_STREAM`. 

--- a/examples/fastapi-response-streaming/app/Dockerfile
+++ b/examples/fastapi-response-streaming/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 WORKDIR /app
 ADD . .

--- a/examples/fastapi-zip/README.md
+++ b/examples/fastapi-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Web Adapter to run a FastAPI application on
 We add Lambda Web Adapter layer to the function and configure wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 

--- a/examples/fastapi-zip/template.yaml
+++ b/examples/fastapi-zip/template.yaml
@@ -21,7 +21,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         ApiEvent:
           Type: HttpApi

--- a/examples/fastapi/README.md
+++ b/examples/fastapi/README.md
@@ -10,7 +10,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is a Fast
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.8.12-slim-buster
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /var/task
 COPY requirements.txt ./
@@ -22,7 +22,7 @@ CMD exec uvicorn --port=$PORT main:app
 Line 2 copies lambda web adapter binary into /opt/extensions. This is the change to run the FastAPI application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/fastapi/app/Dockerfile
+++ b/examples/fastapi/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /var/task
 COPY requirements.txt ./

--- a/examples/fasthtml-response-streaming-zip/README.md
+++ b/examples/fasthtml-response-streaming-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Web Adapter to run a [FastHTML](https://fas
 We add Lambda Web Adapter layer to the function and configure wrapper script.
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script.
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application.
 
@@ -30,7 +30,7 @@ This is the resource for Lambda function. The function urls's invoke mode is con
           AWS_LWA_INVOKE_MODE: response_stream
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/examples/fasthtml-response-streaming-zip/template.yaml
+++ b/examples/fasthtml-response-streaming-zip/template.yaml
@@ -22,7 +22,7 @@ Resources:
           AWS_LWA_INVOKE_MODE: response_stream
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/examples/fasthtml-response-streaming/README.md
+++ b/examples/fasthtml-response-streaming/README.md
@@ -14,7 +14,7 @@ This function is packaged as a Docker image. Here is the content of the Dockerfi
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 WORKDIR /app
 ADD . .
@@ -26,7 +26,7 @@ CMD ["python", "main.py"]
 Notice that we only need to add the second line to install Lambda Web Adapter. 
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/
 ```
 
 In the SAM template, we use an environment variable `AWS_LWA_INVOKE_MODE: RESPONSE_STREAM` to configure Lambda Web Adapter in response streaming mode. And adding a function url with `InvokeMode: RESPONSE_STREAM`. 

--- a/examples/fasthtml-response-streaming/app/Dockerfile
+++ b/examples/fasthtml-response-streaming/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 WORKDIR /app
 ADD . .

--- a/examples/fasthtml-zip/README.md
+++ b/examples/fasthtml-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Web Adapter to run a FastHTML application o
 We add Lambda Web Adapter layer to the function and configure wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 

--- a/examples/fasthtml-zip/template.yaml
+++ b/examples/fasthtml-zip/template.yaml
@@ -21,7 +21,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         ApiEvent:
           Type: HttpApi

--- a/examples/fasthtml/README.md
+++ b/examples/fasthtml/README.md
@@ -10,7 +10,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is a Fast
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.8.12-slim-buster
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /var/task
 COPY requirements.txt ./
@@ -22,7 +22,7 @@ CMD exec uvicorn --port=$PORT main:app
 Line 2 copies lambda web adapter binary into /opt/extensions. This is the change to run the FastHTML application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/fasthtml/app/Dockerfile
+++ b/examples/fasthtml/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /var/task
 COPY requirements.txt ./

--- a/examples/fastmcp-zip/README.md
+++ b/examples/fastmcp-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Web Adapter to run a FastMCP server on mana
 We add Lambda Web Adapter layer to the function and configure wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 4. configure `AWS_LWA_READINESS_CHECK_PATH` to `/healthz` so the adapter waits for the MCP server to be ready before forwarding requests.

--- a/examples/fastmcp-zip/template.yaml
+++ b/examples/fastmcp-zip/template.yaml
@@ -33,7 +33,7 @@ Resources:
           AWS_LWA_READINESS_CHECK_PATH: /healthz
           AWS_LWA_READINESS_CHECK_HEALTHY_STATUS: 100-499
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28
       Events:
         ApiEvent:
           Type: HttpApi

--- a/examples/fastmcp/README.md
+++ b/examples/fastmcp/README.md
@@ -15,7 +15,7 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir --target=/var/task/deps -r requirements.txt
 
 FROM --platform=linux/amd64 public.ecr.aws/docker/library/python:3.14-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000 PYTHONPATH=/var/task/deps
 ENV AWS_LWA_READINESS_CHECK_PATH=/healthz
 ENV AWS_LWA_READINESS_CHECK_HEALTHY_STATUS=100-499
@@ -28,7 +28,7 @@ CMD exec python -m uvicorn --port=$PORT app:app
 Line 7 copies lambda web adapter binary into /opt/extensions. This is the change to run the FastMCP application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/fastmcp/my_mcp_server/Dockerfile
+++ b/examples/fastmcp/my_mcp_server/Dockerfile
@@ -4,7 +4,7 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir --target=/var/task/deps -r requirements.txt
 
 FROM --platform=linux/amd64 public.ecr.aws/docker/library/python:3.14-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000 PYTHONPATH=/var/task/deps
 ENV AWS_LWA_READINESS_CHECK_PATH=/healthz
 ENV AWS_LWA_READINESS_CHECK_HEALTHY_STATUS=100-499

--- a/examples/flask-zip/README.md
+++ b/examples/flask-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Adapter to run an Flask application on mana
 We add Lambda Adapter layer to the function and configure wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 

--- a/examples/flask-zip/template.yaml
+++ b/examples/flask-zip/template.yaml
@@ -21,7 +21,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         ApiEvent:
           Type: HttpApi

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -10,7 +10,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is a flas
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/python:3.8.12-slim-buster
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR /var/task
 COPY app.py requirements.txt ./
 RUN python3.8 -m pip install -r requirements.txt
@@ -20,7 +20,7 @@ CMD ["gunicorn", "-b=:8080", "-w=1", "app:app"]
 Line 2 copies lambda adapter binary into /opt/extensions. This is the only change to run the Flask application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/flask/app/Dockerfile
+++ b/examples/flask/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12.1-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR /var/task
 COPY app.py requirements.txt ./
 RUN python -m pip install -r requirements.txt

--- a/examples/gin-zip/template.yaml
+++ b/examples/gin-zip/template.yaml
@@ -22,7 +22,7 @@ Resources:
           PORT: 8000
           GIN_MODE: release
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         APIEvent:
           Type: HttpApi

--- a/examples/gin/app/Dockerfile
+++ b/examples/gin/app/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 RUN GOOS=linux CGO_ENABLED=0 go build -o bootstrap .
 FROM alpine:3.9 
 RUN apk add ca-certificates
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 COPY --from=build_base /tmp/gin/bootstrap /app/bootstrap
 
 ENV PORT=8000 GIN_MODE=release

--- a/examples/go-http-zip/template.yml
+++ b/examples/go-http-zip/template.yml
@@ -17,7 +17,7 @@ Resources:
         Variables:
           PORT: 3000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         APIEvent:
           Type: HttpApi

--- a/examples/javalin-zip/README.md
+++ b/examples/javalin-zip/README.md
@@ -44,7 +44,7 @@ In the configuration we have to specify the AWS Lambda adapter as a layer and co
           REMOVE_BASE_PATH: /v1
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28
 ```
 
 ### Remove the base path

--- a/examples/javalin-zip/template.yaml
+++ b/examples/javalin-zip/template.yaml
@@ -38,7 +38,7 @@ Resources:
           AWS_LWA_READINESS_CHECK_PORT: 8081
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28
 #        - !Sub arn:aws:lambda:${AWS::Region}:753240598076:layer:LambdaAdapterLayerX86:20
       Events:
         Root:

--- a/examples/nextjs-response-streaming/Dockerfile
+++ b/examples/nextjs-response-streaming/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN npm ci && npm run build
 
 FROM public.ecr.aws/docker/library/node:20.9.0-slim as runner
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 ENV PORT=3000 NODE_ENV=production
 

--- a/examples/nextjs-zip/template.yaml
+++ b/examples/nextjs-zip/template.yaml
@@ -26,7 +26,7 @@ Resources:
           RUST_LOG: info
           PORT: 8000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         RootEvent:
           Type: HttpApi

--- a/examples/nextjs/app/Dockerfile
+++ b/examples/nextjs/app/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN npm ci && npm run build
 
 FROM public.ecr.aws/docker/library/node:20.9.0-slim as runner
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=3000 NODE_ENV=production HOSTNAME=0.0.0.0
 ENV AWS_LWA_ENABLE_COMPRESSION=true
 WORKDIR /app

--- a/examples/nginx-zip/template.yaml
+++ b/examples/nginx-zip/template.yaml
@@ -24,7 +24,7 @@ Resources:
           RUST_LOG: debug
           PORT: 8080
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
         - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:Nginx123X86:12
       Events:
         Root:

--- a/examples/nginx/Dockerfile
+++ b/examples/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/awsguru/nginx:1.23.2023.3.11.1
 
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 # config files
 ADD nginx/conf/nginx.conf /opt/nginx/conf/nginx.conf

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -14,7 +14,7 @@ a [Dockerfile](Dockerfile).
 ```dockerfile
 FROM public.ecr.aws/awsguru/nginx:1.23.2023.3.11.1
 
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 # config files
 ADD nginx/conf/nginx.conf /opt/nginx/conf/nginx.conf
@@ -28,7 +28,7 @@ EXPOSE 8080
 Line 3 copies Lambda adapter binary into /opt/extensions. This is the main change to run the Nginx server on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/php-zip/template.yaml
+++ b/examples/php-zip/template.yaml
@@ -33,7 +33,7 @@ Resources:
           RUST_LOG: debug
           PORT: 8080
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
         - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:Php82FpmNginxX86:13
       Events:
         Root:

--- a/examples/php/Dockerfile
+++ b/examples/php/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /var/task/app
 RUN composer install --prefer-dist --optimize-autoloader --no-dev --no-interaction
 
 FROM public.ecr.aws/awsguru/php:82.2023.3.11.1
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 COPY --from=builder /var/task /var/task
 
 # config files

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -21,7 +21,7 @@ WORKDIR /var/task/app
 RUN composer install --prefer-dist --optimize-autoloader --no-dev --no-interaction
 
 FROM public.ecr.aws/awsguru/php:82.2023.3.11.1
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 COPY --from=builder /var/task /var/task
 
 # config files

--- a/examples/remix-zip/README.md
+++ b/examples/remix-zip/README.md
@@ -13,8 +13,8 @@ npx create-remix@latest --template remix-run/remix/templates/express
 We add Lambda Adapter layer to the function and configure wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 

--- a/examples/remix-zip/template.yaml
+++ b/examples/remix-zip/template.yaml
@@ -26,7 +26,7 @@ Resources:
           RUST_LOG: info
           PORT: 3000
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         HttpEvents:
           Type: HttpApi

--- a/examples/remix/Dockerfile
+++ b/examples/remix/Dockerfile
@@ -4,7 +4,7 @@ ADD . .
 RUN cd remix-app && npm install && npm run build && npm prune --omit=dev
 
 FROM public.ecr.aws/docker/library/node:20-bookworm-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR "/var/task"
 COPY --from=builder  /var/task/remix-app/build /var/task/build
 COPY --from=builder  /var/task/remix-app/node_modules /var/task/node_modules

--- a/examples/remix/README.md
+++ b/examples/remix/README.md
@@ -21,7 +21,7 @@ ADD . .
 RUN cd remix-app && npm install && npm run build && npm prune --omit=dev
 
 FROM public.ecr.aws/docker/library/node:20-bookworm-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR "/var/task"
 COPY --from=builder  /var/task/remix-app/build /var/task/build
 COPY --from=builder  /var/task/remix-app/node_modules /var/task/node_modules

--- a/examples/rust-actix-web-zip/template.yaml
+++ b/examples/rust-actix-web-zip/template.yaml
@@ -22,7 +22,7 @@ Resources:
       Architectures:
         - arm64
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28
       Events:
         HttpEvents:
           Type: HttpApi # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/examples/rust-axum-zip/template.yaml
+++ b/examples/rust-axum-zip/template.yaml
@@ -20,7 +20,7 @@ Resources:
       Architectures:
         - arm64
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28
       Events:
         Root:
           Type: HttpApi # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/examples/sinatra/README.md
+++ b/examples/sinatra/README.md
@@ -9,7 +9,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is a Sina
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/ruby:3.3
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR /var/task
 COPY Gemfile Gemfile.lock ./
 RUN bundle install

--- a/examples/sinatra/app/Dockerfile
+++ b/examples/sinatra/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/ruby:3.3
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 WORKDIR /var/task
 COPY ./src ./
 RUN bundle install

--- a/examples/sls/nestjs/Dockerfile
+++ b/examples/sls/nestjs/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN pnpm install && pnpm run build
 
 FROM public.ecr.aws/docker/library/node:18.19-slim as runner
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 ENV PORT=8080 NODE_ENV=production
 ENV AWS_LWA_ENABLE_COMPRESSION=true

--- a/examples/springboot-response-streaming-zip/README.md
+++ b/examples/springboot-response-streaming-zip/README.md
@@ -31,7 +31,7 @@ In the configuration we have to specify the AWS Lambda adapter as a layer and co
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           AWS_LWA_INVOKE_MODE: response_stream
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
 ```
 In this template, we enable SnapStart for this function. SnapStart drastically reduces cold start time for Java functions using Firecracker MicroVM snapshotting technology. Read more about SnapStart [here](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html).
 

--- a/examples/springboot-response-streaming-zip/template.yaml
+++ b/examples/springboot-response-streaming-zip/template.yaml
@@ -28,7 +28,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           AWS_LWA_INVOKE_MODE: response_stream
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/examples/springboot-zip/README.md
+++ b/examples/springboot-zip/README.md
@@ -31,7 +31,7 @@ In the configuration we have to specify the AWS Lambda adapter as a layer and co
           REMOVE_BASE_PATH: /v1
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
 ```
 
 In this template, we enable SnapStart for this function. SnapStart drastically reduces cold start time for Java functions using Firecracker MicroVM snapshotting technology. Read more about SnapStart [here](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html).

--- a/examples/springboot-zip/template.yaml
+++ b/examples/springboot-zip/template.yaml
@@ -28,7 +28,7 @@ Resources:
           REMOVE_BASE_PATH: /v1
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:
         Root:
           Type: HttpApi

--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -16,7 +16,7 @@ COPY pom.xml ./
 RUN mvn -q clean package
 
 FROM public.ecr.aws/docker/library/amazoncorretto:8u322-al2
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /opt
 COPY --from=build-image /task/target/petstore-0.0.1-SNAPSHOT.jar /opt
@@ -26,7 +26,7 @@ CMD ["java", "-jar", "petstore-0.0.1-SNAPSHOT.jar", "--server.port=${PORT}"]
 Line 7 copies lambda adapter binary to /opt/extensions. This is the only change to run the Spring Boot application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Remove the base path

--- a/examples/springboot/app/Dockerfile
+++ b/examples/springboot/app/Dockerfile
@@ -5,7 +5,7 @@ COPY pom.xml ./
 RUN mvn -q clean package
 
 FROM public.ecr.aws/docker/library/amazoncorretto:8u322-al2
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000
 WORKDIR /opt
 COPY --from=build-image /task/target/petstore-0.0.1-SNAPSHOT.jar /opt

--- a/examples/sqs-expressjs/README.md
+++ b/examples/sqs-expressjs/README.md
@@ -10,7 +10,7 @@ The top level folder is a typical AWS SAM project. The `app` directory is an exp
 
 ```dockerfile
 FROM public.ecr.aws/docker/library/node:20-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000 AWS_LWA_READINESS_CHECK_PROTOCOL=tcp
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json
@@ -23,7 +23,7 @@ CMD ["node", "index.js"]
 Line 2 copies lambda adapter binary into /opt/extensions. This is the only change to run the express.js application on Lambda.
 
 ```dockerfile
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ```
 
 ## Pre-requisites

--- a/examples/sqs-expressjs/app/Dockerfile
+++ b/examples/sqs-expressjs/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/node:20-slim
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=8000 AWS_LWA_READINESS_CHECK_PROTOCOL=tcp
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json

--- a/examples/sveltekit-ssr-zip/README.md
+++ b/examples/sveltekit-ssr-zip/README.md
@@ -7,8 +7,8 @@ This example shows how to use Lambda Web Adapter to run a [server side rendered 
 Add the Lambda Web Adapter layer to the function and configure the wrapper script. 
 
 1. attach Lambda Adapter layer to your function. This layer contains the Lambda Adapter binary and a wrapper script. 
-    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27`
-    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:27`
+    1. x86_64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28`
+    2. arm64: `arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerArm64:28`
 2. configure Lambda environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`. This is a wrapper script included in the layer.
 3. set function handler to a startup command: `run.sh`. The wrapper script will execute this command to boot up your application. 
 

--- a/examples/sveltekit-ssr-zip/template.yaml
+++ b/examples/sveltekit-ssr-zip/template.yaml
@@ -25,7 +25,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           PORT: 8080
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:27
+        - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       FunctionUrlConfig:
         AuthType: NONE
     Metadata:


### PR DESCRIPTION
## Description

Updates documentation and examples for the v1.0.1 release, mirroring the 1.0.0 docs update in #689.

- **Docker image tag**: `public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0` → `:1.0.1` (README, user guide, Dockerfiles, example READMEs, `examples.yaml` CI workflow)
- **Lambda layer version**: `LambdaAdapterLayer{X86,Arm64}:27` → `:28` (README, user guide, SAM templates, example READMEs, CDK app)

## Verification

The commercial layer version `:28` was confirmed against the actual `v1.0.1` release run (`sam deploy` CloudFormation outputs), e.g. `arn:aws:lambda:us-east-1:753240598075:layer:LambdaAdapterLayerX86:28` (verified consistent across the sampled commercial regions for both x86_64 and arm64).

The Docker tag is derived directly from `CARGO_PKG_VERSION` in the release workflow, so `1.0.1` is exact.

> Note: the AWS China region ARNs are kept in lockstep with the commercial version per the existing docs convention. China prod layers are not deployed by the current release pipeline (the `deploy-china-prod` job is disabled), so their published version should be confirmed in the AWS China console if exactness is required.

## Type of change

- [x] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)