### PR TITLE
ci: fix stale cliff.toml remote owner (awslabs -> aws)

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -67,5 +67,5 @@ tag_pattern = "v[0-9].*"
 sort_commits = "newest"
 
 [remote.github]
-owner = "awslabs"
+owner = "aws"
 repo = "aws-lambda-web-adapter"


### PR DESCRIPTION
## Summary

Fix the stale `cliff.toml` GitHub remote owner so git-cliff's API enrichment resolves correctly.

```diff
 [remote.github]
-owner = "awslabs"
+owner = "aws"
 repo = "aws-lambda-web-adapter"
```

The repo lives at `aws/aws-lambda-web-adapter`, not `awslabs/...`, so the old value pointed git-cliff's GitHub API lookups (PR / author enrichment) at the wrong owner.

## Scope change

This PR originally also reworked the `Changelog` workflow to open a PR instead of pushing to the protected `main` branch. Per [maintainer feedback](https://github.com/aws/aws-lambda-web-adapter/pull/747#issuecomment-4594445136), the release pipeline will instead be refactored using [`release-plz`](https://github.com/release-plz/release-plz), so that workflow rework is dropped here.

The PR is now narrowed to the single obvious `cliff.toml` fix, leaving the broader release-pipeline redesign to the `release-plz` effort.
