### PR TITLE
ci(examples): assert exact status/body instead of liveness-only check

### DIFF
--- a/.github/scripts/verify-http.sh
+++ b/.github/scripts/verify-http.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Verify that an example's HTTP endpoint serves the expected response.
+#
+# Unlike a plain liveness check (any 2xx-4xx == "OK"), this asserts that a
+# specific route returns an exact status code and, optionally, that the body
+# contains a known substring. This catches broken routing and apps that boot
+# but serve the wrong (or empty) content.
+#
+# Usage:
+#   verify-http.sh <base_url> <path> <expect_status> [expect_body]
+#
+#   base_url      e.g. http://127.0.0.1:3000
+#   path          request path, e.g. / or /healthz
+#   expect_status comma-separated acceptable status codes, e.g. "200" or "200,307"
+#   expect_body   optional substring that must appear in the response body
+#
+# Waits up to 90s (wall-clock) for the endpoint to satisfy BOTH conditions
+# (the app may still be warming up), then exits 0 on success or 1 with
+# diagnostics. Uses a wall-clock deadline plus a short per-request timeout
+# (curl -m 5) so a hanging endpoint can't multiply the wait window.
+
+set -uo pipefail
+
+BASE_URL="${1:?base_url required}"
+REQ_PATH="${2:-/}"
+EXPECT_STATUS="${3:-200}"
+EXPECT_BODY="${4:-}"
+
+URL="${BASE_URL%/}${REQ_PATH}"
+IFS=',' read -ra ACCEPT <<< "$EXPECT_STATUS"
+
+status_ok() {
+  local s="$1"
+  for code in "${ACCEPT[@]}"; do
+    [ "$s" = "$code" ] && return 0
+  done
+  return 1
+}
+
+echo "Verifying ${URL} (expect status ${EXPECT_STATUS}${EXPECT_BODY:+, body contains \"${EXPECT_BODY}\"})"
+
+last_status=""
+last_body=""
+START=$SECONDS
+DEADLINE=$((START + 90))
+while [ $SECONDS -lt $DEADLINE ]; do
+  resp="$(curl -s -m 5 -w $'\n%{http_code}' "$URL" 2>/dev/null || true)"
+  last_status="${resp##*$'\n'}"
+  last_body="${resp%$'\n'*}"
+  if status_ok "$last_status"; then
+    if [ -z "$EXPECT_BODY" ] || grep -qF -- "$EXPECT_BODY" <<< "$last_body"; then
+      echo "OK after $((SECONDS - START))s: status ${last_status}${EXPECT_BODY:+, body contains \"${EXPECT_BODY}\"}"
+      exit 0
+    fi
+  fi
+  sleep 1
+done
+
+echo "FAIL: expectation not met within 90s (elapsed $((SECONDS - START))s)"
+echo "  last status: ${last_status:-<none>} (expected ${EXPECT_STATUS})"
+[ -n "$EXPECT_BODY" ] && echo "  expected body substring: ${EXPECT_BODY}"
+echo "--- last response body (first 30 lines) ---"
+printf '%s\n' "$last_body" | head -30
+exit 1

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -76,7 +76,9 @@ jobs:
           name: layer-x86_64
           path: layer-x86_64/
 
-  # Docker-based examples verified with sam local start-api.
+  # Docker-based examples verified with sam local start-api. Each matrix entry
+  # asserts an exact status (and optional body substring) via verify-http.sh,
+  # not just liveness.
   # Excluded: nginx, php, flask, aspnet-mvc (web app hardcodes port 8080
   # which conflicts with SAM's Lambda Runtime Interface Emulator).
   test-image:
@@ -86,14 +88,14 @@ jobs:
       fail-fast: false
       matrix:
         example:
-          - expressjs
-          - fastapi
-          - fastapi-background-tasks
-          - fasthtml
-          - gin
-          - nextjs
-          - remix
-          - springboot
+          - { name: expressjs, path: /, expect_body: "Hi there!" }
+          - { name: fastapi, path: /, expect_body: "message" }
+          - { name: fastapi-background-tasks, path: /, expect_body: "message" }
+          - { name: fasthtml, path: /, expect_body: "Hello World" }
+          - { name: gin, path: /, expect_body: "message" }
+          - { name: nextjs, path: /, expect_body: "Next.js Logo" }
+          - { name: remix, path: /, expect_body: "Welcome to" }
+          - { name: springboot, path: /v1/, expect_body: "Hello, world!" }
     steps:
       - uses: actions/checkout@v4
 
@@ -113,12 +115,21 @@ jobs:
 
       - name: Build local adapter image
         run: |
+          # Build the local adapter under every tag the example Dockerfiles
+          # reference, so each example's `docker build` (COPY --from=...:<tag>)
+          # uses the locally compiled binary instead of pulling the released
+          # image. Deriving the tags from the Dockerfiles keeps CI in lockstep
+          # with them (no hardcoded version to forget at release time).
           chmod +x /tmp/layer-x86_64/lambda-adapter
-          printf 'FROM scratch\nCOPY --chmod=755 lambda-adapter /lambda-adapter\n' | \
-            docker build -t public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 -f- /tmp/layer-x86_64
+          tags=$(grep -rhoE 'aws-lambda-adapter:[0-9A-Za-z._-]+' examples | sed 's/.*://' | sort -u)
+          echo "Building local adapter for tags: $tags"
+          for tag in $tags; do
+            printf 'FROM scratch\nCOPY --chmod=755 lambda-adapter /lambda-adapter\n' | \
+              docker build -t public.ecr.aws/awsguru/aws-lambda-adapter:$tag -f- /tmp/layer-x86_64
+          done
 
       - name: Build
-        working-directory: examples/${{ matrix.example }}
+        working-directory: examples/${{ matrix.example.name }}
         run: |
           # Retry to tolerate transient registry rate limits (toomanyrequests: Rate
           # exceeded). public.ecr.aws throttles unauthenticated pulls at ~1 req/s per
@@ -140,43 +151,29 @@ jobs:
           done
 
       - name: Start local API and verify
-        working-directory: examples/${{ matrix.example }}
+        working-directory: examples/${{ matrix.example.name }}
         run: |
-          # Set PORT=8000 to avoid conflict with SAM's RIE on port 8080
+          # Set PORT=8000 to avoid conflict with SAM's RIE on port 8080.
+          # Start and verify in the same step so the backgrounded sam local
+          # stays attached to this shell while requests are served (splitting
+          # it across steps races the container warm-up and yields 500s).
           echo '{"Parameters":{"PORT":"8000"}}' > /tmp/env.json
           sam local start-api --port 3000 --warm-containers EAGER --container-env-vars /tmp/env.json &
-          SAM_PID=$!
-          echo "SAM_PID=$SAM_PID" >> $GITHUB_ENV
-
-          echo "Waiting for local API to start..."
-          for i in $(seq 1 90); do
-            if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/ 2>/dev/null | grep -q "^[2345]"; then
-              echo "API is ready after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 90 ]; then
-              echo "API failed to start within 90s"
-              kill $SAM_PID 2>/dev/null || true
-              exit 1
-            fi
-            sleep 1
-          done
-
-          status=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/)
-          echo "HTTP status: $status"
-          if [[ "$status" -ge 200 && "$status" -lt 500 ]]; then
-            echo "OK: Got valid response"
-          else
-            echo "FAIL: Unexpected status $status"
-            kill $SAM_PID 2>/dev/null || true
-            exit 1
-          fi
+          echo "SAM_PID=$!" >> $GITHUB_ENV
+          "$GITHUB_WORKSPACE/.github/scripts/verify-http.sh" \
+            http://127.0.0.1:3000 \
+            "${{ matrix.example.path }}" \
+            200 \
+            "${{ matrix.example.expect_body }}"
 
       - name: Stop local API
         if: always()
         run: kill $SAM_PID 2>/dev/null || true
 
-  # Zip-based examples verified with local layer.
+  # Zip-based examples verified with local layer. Each matrix entry asserts an
+  # exact status (and optional body substring) via verify-http.sh.
+  # `port` is the app's listening port, passed through to the adapter via the
+  # PORT parameter; it must differ from SAM's RIE port (8080).
   # Excluded: aspnet-*-zip (hardcode port 8080),
   # bun/nginx/php-zip (need third-party layers), arm64 examples (javalin, rust-*),
   # nextjs-zip (Makefile produces a zip artifact incompatible with sam local).
@@ -187,14 +184,14 @@ jobs:
       fail-fast: false
       matrix:
         example:
-          - deno-zip
-          - expressjs-zip
-          - fastapi-zip
-          - fasthtml-zip
-          - flask-zip
-          - gin-zip
-          - remix-zip
-          - springboot-zip
+          - { name: deno-zip, path: /, expect_body: "success", port: "8000" }
+          - { name: expressjs-zip, path: /, expect_body: "Hi there!", port: "8000" }
+          - { name: fastapi-zip, path: /, expect_body: "message", port: "8000" }
+          - { name: fasthtml-zip, path: /, expect_body: "Hello World", port: "8000" }
+          - { name: flask-zip, path: /, expect_body: "message", port: "8000" }
+          - { name: gin-zip, path: /, expect_body: "message", port: "8000" }
+          - { name: remix-zip, path: /, expect_body: "Welcome to", port: "8000" }
+          - { name: springboot-zip, path: /v1/, expect_body: "Hello, world!", port: "8000" }
     steps:
       - uses: actions/checkout@v4
 
@@ -208,7 +205,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: denoland/setup-deno@v2
-        if: matrix.example == 'deno-zip'
+        if: matrix.example.name == 'deno-zip'
         with:
           deno-version: v2.x
 
@@ -218,7 +215,7 @@ jobs:
           path: /tmp/layer-x86_64
 
       - name: Build
-        working-directory: examples/${{ matrix.example }}
+        working-directory: examples/${{ matrix.example.name }}
         run: |
           # Retry to tolerate transient registry rate limits (toomanyrequests: Rate
           # exceeded). public.ecr.aws throttles unauthenticated pulls at ~1 req/s per
@@ -240,7 +237,7 @@ jobs:
           done
 
       - name: Inject local layer into build output
-        working-directory: examples/${{ matrix.example }}
+        working-directory: examples/${{ matrix.example.name }}
         run: |
           # Prepare local layer directory with correct structure
           LAYER_DIR=".aws-sam/build/LocalAdapterLayer"
@@ -268,47 +265,36 @@ jobs:
           PYEOF
 
       - name: Start local API and verify
-        working-directory: examples/${{ matrix.example }}
+        working-directory: examples/${{ matrix.example.name }}
         run: |
-          # Set PORT=8000 to avoid conflict with SAM's RIE on port 8080
-          echo '{"Parameters":{"PORT":"8000"}}' > /tmp/env.json
+          # Pass the app's listening port via PORT (must differ from RIE's 8080).
+          # Start and verify in the same step so the backgrounded sam local
+          # stays attached to this shell while requests are served (splitting
+          # it across steps races the container warm-up and yields 500s).
+          echo '{"Parameters":{"PORT":"${{ matrix.example.port }}"}}' > /tmp/env.json
           sam local start-api --port 3000 --warm-containers EAGER --container-env-vars /tmp/env.json &
-          SAM_PID=$!
-          echo "SAM_PID=$SAM_PID" >> $GITHUB_ENV
-
-          echo "Waiting for local API to start..."
-          for i in $(seq 1 90); do
-            if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/ 2>/dev/null | grep -q "^[2345]"; then
-              echo "API is ready after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 90 ]; then
-              echo "API failed to start within 90s"
-              kill $SAM_PID 2>/dev/null || true
-              exit 1
-            fi
-            sleep 1
-          done
-
-          status=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/)
-          echo "HTTP status: $status"
-          if [[ "$status" -ge 200 && "$status" -lt 500 ]]; then
-            echo "OK: Got valid response"
-          else
-            echo "FAIL: Unexpected status $status"
-            kill $SAM_PID 2>/dev/null || true
-            exit 1
-          fi
+          echo "SAM_PID=$!" >> $GITHUB_ENV
+          "$GITHUB_WORKSPACE/.github/scripts/verify-http.sh" \
+            http://127.0.0.1:3000 \
+            "${{ matrix.example.path }}" \
+            200 \
+            "${{ matrix.example.expect_body }}"
 
       - name: Stop local API
         if: always()
         run: kill $SAM_PID 2>/dev/null || true
 
   # Response-streaming examples verified by building and running the real app,
-  # then curling /. These use a Lambda Function URL with RESPONSE_STREAM and have
-  # no API Gateway events, so sam local start-api (used by test-image/test-zip)
-  # cannot drive them. Without this job they were only lint-validated, which let
-  # a broken python-fasthtml pin (ModuleNotFoundError: sqlite_minutils) ship.
+  # then asserting an exact status/body with verify-http.sh. These use a Lambda
+  # Function URL with RESPONSE_STREAM and have no API Gateway events, so
+  # sam local start-api (used by test-image/test-zip) cannot drive them.
+  #
+  # `kind` selects how the app is launched:
+  #   image        - build the app image (its Dockerfile COPYs the local adapter
+  #                  image built below) and run it; map host 8000 to `appport`.
+  #   zip-fasthtml - run `python app/main.py` (FastHTML's serve() binds 8000).
+  # AWS_REGION is set so boto3 / AnthropicBedrock clients construct without real
+  # creds; the verified routes only render UI and never call Bedrock.
   test-stream:
     needs: [build-layer]
     runs-on: ubuntu-24.04
@@ -316,8 +302,8 @@ jobs:
       fail-fast: false
       matrix:
         example:
-          - fasthtml-response-streaming
-          - fasthtml-response-streaming-zip
+          - { name: fasthtml-response-streaming, kind: image, appport: "8080", path: /, expect_body: "Serverless Bedtime" }
+          - { name: fasthtml-response-streaming-zip, kind: zip-fasthtml, path: /, expect_body: "Click to stream" }
     steps:
       - uses: actions/checkout@v4
 
@@ -332,59 +318,52 @@ jobs:
 
       - name: Build local adapter image
         run: |
+          # Build the local adapter under every tag the example Dockerfiles
+          # reference, so each example's `docker build` (COPY --from=...:<tag>)
+          # uses the locally compiled binary instead of pulling the released
+          # image. Deriving the tags from the Dockerfiles keeps CI in lockstep
+          # with them (no hardcoded version to forget at release time).
           chmod +x /tmp/layer-x86_64/lambda-adapter
-          printf 'FROM scratch\nCOPY --chmod=755 lambda-adapter /lambda-adapter\n' | \
-            docker build -t public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 -f- /tmp/layer-x86_64
+          tags=$(grep -rhoE 'aws-lambda-adapter:[0-9A-Za-z._-]+' examples | sed 's/.*://' | sort -u)
+          echo "Building local adapter for tags: $tags"
+          for tag in $tags; do
+            printf 'FROM scratch\nCOPY --chmod=755 lambda-adapter /lambda-adapter\n' | \
+              docker build -t public.ecr.aws/awsguru/aws-lambda-adapter:$tag -f- /tmp/layer-x86_64
+          done
 
       - name: Build and start app
-        working-directory: examples/${{ matrix.example }}
+        working-directory: examples/${{ matrix.example.name }}
+        env:
+          KIND: ${{ matrix.example.kind }}
+          APPPORT: ${{ matrix.example.appport }}
         run: |
-          if [ "${{ matrix.example }}" = "fasthtml-response-streaming" ]; then
-            # Image example: build the app image (its Dockerfile COPYs the local
-            # adapter image built above) and run it. The app serves on 8080;
-            # map it to host 8000 so the verify step is port-agnostic. AWS_REGION
-            # lets AnthropicBedrock() construct without real creds; GET / only
-            # renders a form and never calls Bedrock.
-            docker build -t fasthtml-stream app
-            docker run -d --name fasthtml-stream \
-              -e AWS_REGION=us-east-1 -e AWS_DEFAULT_REGION=us-east-1 \
-              -p 8000:8080 fasthtml-stream
-          else
-            # Zip example: run the app directly. run.sh only adds Lambda-layer
-            # paths needed at runtime on Lambda, not locally.
-            pip install -r app/requirements.txt
-            PORT=8000 nohup python app/main.py > /tmp/app.log 2>&1 &
-            echo "APP_PID=$!" >> $GITHUB_ENV
-          fi
+          case "$KIND" in
+            image)
+              docker build -t stream-app app
+              docker run -d --name stream-app \
+                -e PORT=8000 -e AWS_REGION=us-east-1 -e AWS_DEFAULT_REGION=us-east-1 \
+                -p "8000:${APPPORT}" stream-app
+              ;;
+            zip-fasthtml)
+              pip install -r app/requirements.txt
+              PORT=8000 nohup python app/main.py > /tmp/app.log 2>&1 &
+              echo "APP_PID=$!" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "Unknown kind: $KIND"; exit 1 ;;
+          esac
 
       - name: Verify
         run: |
-          echo "Waiting for app to start..."
-          for i in $(seq 1 90); do
-            if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/ 2>/dev/null | grep -q "^[2345]"; then
-              echo "App is ready after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 90 ]; then
-              echo "App failed to start within 90s"
-              docker logs fasthtml-stream 2>/dev/null || cat /tmp/app.log 2>/dev/null || true
-              exit 1
-            fi
-            sleep 1
-          done
-
-          status=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/)
-          echo "HTTP status: $status"
-          if [[ "$status" -ge 200 && "$status" -lt 500 ]]; then
-            echo "OK: Got valid response"
-          else
-            echo "FAIL: Unexpected status $status"
-            docker logs fasthtml-stream 2>/dev/null || cat /tmp/app.log 2>/dev/null || true
-            exit 1
-          fi
+          "$GITHUB_WORKSPACE/.github/scripts/verify-http.sh" \
+            http://127.0.0.1:8000 \
+            "${{ matrix.example.path }}" \
+            200 \
+            "${{ matrix.example.expect_body }}" \
+          || { echo "--- app logs ---"; docker logs stream-app 2>/dev/null || cat /tmp/app.log 2>/dev/null || true; exit 1; }
 
       - name: Stop app
         if: always()
         run: |
-          docker rm -f fasthtml-stream 2>/dev/null || true
+          docker rm -f stream-app 2>/dev/null || true
           kill $APP_PID 2>/dev/null || true

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -291,7 +291,7 @@ jobs:
   #
   # `kind` selects how the app is launched:
   #   image        - build the app image (its Dockerfile COPYs the local adapter
-  #                  image built below) and run it; map host 8000 to `appport`.
+  #                  image built below) and run it with PORT=8000.
   #   zip-fasthtml - run `python app/main.py` (FastHTML's serve() binds 8000).
   # AWS_REGION is set so boto3 / AnthropicBedrock clients construct without real
   # creds; the verified routes only render UI and never call Bedrock.
@@ -302,7 +302,7 @@ jobs:
       fail-fast: false
       matrix:
         example:
-          - { name: fasthtml-response-streaming, kind: image, appport: "8080", path: /, expect_body: "Serverless Bedtime" }
+          - { name: fasthtml-response-streaming, kind: image, path: /, expect_body: "Serverless Bedtime" }
           - { name: fasthtml-response-streaming-zip, kind: zip-fasthtml, path: /, expect_body: "Click to stream" }
     steps:
       - uses: actions/checkout@v4
@@ -335,14 +335,13 @@ jobs:
         working-directory: examples/${{ matrix.example.name }}
         env:
           KIND: ${{ matrix.example.kind }}
-          APPPORT: ${{ matrix.example.appport }}
         run: |
           case "$KIND" in
             image)
               docker build -t stream-app app
               docker run -d --name stream-app \
                 -e PORT=8000 -e AWS_REGION=us-east-1 -e AWS_DEFAULT_REGION=us-east-1 \
-                -p "8000:${APPPORT}" stream-app
+                -p "8000:8000" stream-app
               ;;
             zip-fasthtml)
               pip install -r app/requirements.txt

--- a/examples/expressjs-zip/template.yaml
+++ b/examples/expressjs-zip/template.yaml
@@ -24,6 +24,9 @@ Resources:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
           RUST_LOG: info
+          # Listen on 8000 so the app doesn't collide with SAM's Runtime
+          # Interface Emulator on 8080 during local testing.
+          PORT: 8000
       Layers:
         - !Sub arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:28
       Events:

--- a/examples/expressjs/README.md
+++ b/examples/expressjs/README.md
@@ -11,7 +11,8 @@ The top level folder is a typical AWS SAM project. The `app` directory is an exp
 ```dockerfile
 FROM public.ecr.aws/docker/library/node:16.13.2-stretch-slim
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
-EXPOSE 8080
+ENV PORT=8000
+EXPOSE 8000
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json
 ADD src/package-lock.json /var/task/package-lock.json
@@ -69,12 +70,12 @@ $ curl https://xxxxxxxxxx.execute-api.us-west-2.amazonaws.com/
 We can run the same docker image locally, so that we know it can be deployed to ECS Fargate and EKS EC2 without code changes.
 
 ```shell
-$ docker run -d -p 8080:8080 {ECR Image}
+$ docker run -d -p 8000:8000 {ECR Image}
 
 ```
 
 Use curl to verify the docker container works.
 
 ```shell
-$ curl localhost:8080/ 
+$ curl localhost:8000/ 
 ```

--- a/examples/expressjs/app/Dockerfile
+++ b/examples/expressjs/app/Dockerfile
@@ -1,6 +1,9 @@
 FROM public.ecr.aws/docker/library/node:16.13.2-stretch-slim
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
-EXPOSE 8080
+# Listen on 8000 (the app reads PORT) so it doesn't collide with SAM's Runtime
+# Interface Emulator on 8080 during local testing.
+ENV PORT=8000
+EXPOSE 8000
 WORKDIR "/var/task"
 ADD src/package.json /var/task/package.json
 ADD src/package-lock.json /var/task/package-lock.json

--- a/examples/fasthtml-response-streaming/app/main.py
+++ b/examples/fasthtml-response-streaming/app/main.py
@@ -1,3 +1,4 @@
+import os
 from anthropic import AnthropicBedrock
 import secrets
 from fasthtml.common import *
@@ -57,4 +58,4 @@ async def send(topic: str):
     return StreamingResponse(story_generator(content), media_type="text/plain", 
                              headers={"X-Transfer-Encoding": "chunked"})
 
-serve(port=8080, reload=True)
+serve(port=int(os.environ.get("PORT", "8080")), reload=True)


### PR DESCRIPTION
## Summary

Before this PR, the verify step in `test-image` / `test-zip` / `test-stream` jobs treated **any 2xx-4xx response as success** (a plain liveness check). That means a broken route returning 404, or an app that booted but served empty/wrong content, would still pass example CI silently.

This PR adds **exact response assertions**: every example now declares the expected HTTP status (and optionally a body substring), and the verify step fails unless the real response matches.

## Changes

- **Adds `.github/scripts/verify-http.sh`** — polls an endpoint until both conditions hold:
  - the status code matches one of the expected values (e.g. `200`, or `200,307` for redirect-then-page)
  - the response body contains an optional expected substring

  Uses a wall-clock deadline (90s) plus a short per-request timeout (`curl -m 5`) so a hanging endpoint can't multiply the wait window. Failure prints the last status, the expected substring, and the first 30 lines of the last body as diagnostics.

- **Updates `.github/workflows/examples.yaml`** — converts the matrix in each verify job from plain example names to objects carrying `{path, expect_status, expect_body}`, so every example asserts its real response.

- **`examples/expressjs/`** — switches the local listen port from 8080 to 8000 (`ENV PORT=8000` + `EXPOSE 8000`) so the example doesn't collide with SAM's Runtime Interface Emulator on 8080 during local testing. README updated to match.

- **`examples/expressjs-zip/template.yaml`** — same `PORT: 8000` adjustment for the zip-style variant, with an inline comment explaining the reason.

- **`examples/fasthtml-response-streaming/`** — the app hardcoded `serve(port=8080)` and ignored the `PORT` environment variable that every other example (e.g. `fastapi-response-streaming`) already respects. Reads `PORT` with an `8080` fallback so the listening port can be overridden. With the app now honoring `PORT`, the `appport` workaround in the `test-stream` job is dropped: the image case maps `8000:8000` like the rest instead of routing host `8000` to the hardcoded `8080`.

## Test plan

- [ ] All three matrix jobs (`test-image`, `test-zip`, `test-stream`) pass on this PR.
- [ ] Hanging-endpoint case stays bounded: a non-responsive example fails within ~95s instead of multiplying out to ~16 minutes.
- [ ] Failure diagnostic is useful: when an example returns the wrong status/body, the log shows the actual status, the expected substring, and a body excerpt.
- [ ] `fasthtml-response-streaming` honors `PORT=8000` in the `test-stream` image job and the verify step passes against `8000:8000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
