### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v1.1.0 - 2026-07-09
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "lambda_web_adapter"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_web_adapter"
-version = "1.0.1"
+version = "1.1.0"
 authors = [
     "Harold Sun <sunhua@amazon.com>",
     "David Calavera <dcalaver@amazon.com>",


### PR DESCRIPTION
## Summary

Release **v1.1.0**. This is the release-prep change for the version that ships Lambda SnapStart support (merged in #790).

## Changes

- Bump crate version `1.0.1` → `1.1.0` (`Cargo.toml`, `Cargo.lock`).
- Promote the `## Unreleased` CHANGELOG section to `## v1.1.0 - 2026-07-09`.

## Highlights in v1.1.0

- **Lambda SnapStart support** (#790): the adapter bridges the SnapStart lifecycle to the inner web app via two opt-in HTTP hooks — `AWS_LWA_SNAPSTART_BEFORE_CHECKPOINT_PATH` (before checkpoint) and `AWS_LWA_SNAPSTART_AFTER_RESTORE_PATH` (after restore). After restore it refreshes its own HTTP client and re-runs the readiness check before admitting traffic, and rejects external traffic to the hook paths with 403.

No functional code changes in this PR — version/changelog only.
